### PR TITLE
Operation compression

### DIFF
--- a/include/antidote.hrl
+++ b/include/antidote.hrl
@@ -78,6 +78,11 @@
 %% Frequency at which manager requests remote resources.
 -define(TRANSFER_FREQ, 100). %in Milliseconds
 
+%% Enable/Disable operation compression
+-define(OPERATION_COMPRESSION, false).
+%% How long the InterDC Replicator should hold transactions before compressing
+-define(COMPRESSION_TIMER, 200). % in Milliseconds
+
 %% The definition "FIRST_OP" is used by the materializer.
 %% The materialzer caches a tuple for each key containing
 %% information about the state of operations performed on that key.

--- a/include/antidote.hrl
+++ b/include/antidote.hrl
@@ -78,8 +78,6 @@
 %% Frequency at which manager requests remote resources.
 -define(TRANSFER_FREQ, 100). %in Milliseconds
 
-%% Enable/Disable operation compression
--define(OPERATION_COMPRESSION, false).
 %% How long the InterDC Replicator should hold transactions before compressing
 -define(COMPRESSION_TIMER, 200). % in Milliseconds
 

--- a/rebar.config
+++ b/rebar.config
@@ -8,6 +8,7 @@
     %% antidote_pb is client interface. Needed only for riak_tests.
     {antidote_pb, {git, "https://github.com/syncfree/antidote_pb", {tag, "v0.1.0"}}},
     {antidote_crdt, ".*", {git, "https://github.com/gmcabrita/antidote_crdt", {branch, "compression"}}},
+    {rand_compat, "0.0.3"},
     % {rand_compat, {git, "https://github.com/lasp-lang/rand_compat.git", {ref, "b2cf40b6ef14a5d7fbc67276e9164de7cc7c7906"}}},
     % expose metric for prometheus as HTTP-API
     {elli, "2.0.1"},

--- a/rebar.config
+++ b/rebar.config
@@ -7,8 +7,7 @@
     {erlzmq, {git, "https://github.com/tcrain/erlzmq2", {ref, "f40b84ed2947a2bb0dfdbf2f0e0d006beec54b0b"}}},
     %% antidote_pb is client interface. Needed only for riak_tests.
     {antidote_pb, {git, "https://github.com/syncfree/antidote_pb", {tag, "v0.1.0"}}},
-    {antidote_crdt, ".*", {git, "https://github.com/syncfree/antidote_crdt", {tag, "0.0.6"}}},
-    {rand_compat, "0.0.3"}, 
+    {antidote_crdt, ".*", {git, "https://github.com/gmcabrita/antidote_crdt", {branch, "compression"}}},
     % {rand_compat, {git, "https://github.com/lasp-lang/rand_compat.git", {ref, "b2cf40b6ef14a5d7fbc67276e9164de7cc7c7906"}}},
     % expose metric for prometheus as HTTP-API
     {elli, "2.0.1"},

--- a/src/antidote.app.src
+++ b/src/antidote.app.src
@@ -49,10 +49,14 @@
   %%        true -> writes to disk done by the logging_vnode are enabled
   %%        false -> writes to disk are disabled, this improves performance when benchmarking.
   %%        WARNING: disabling logging makes updates non-recoverable after shutting down antidote or under failures.
+  %% %% operation_compression:
+  %%        true -> enables operations to be compressed before being sent between DCs
+  %%        false -> propagates operations between DCs without compressing
 
   {env, [{txn_cert, true}, {txn_prot, clocksi}, {recover_from_log, true},
          {recover_meta_data_on_start, true}, {sync_log, false},
          {enable_logging, true},
+         {operation_compression, false},
          {auto_start_read_servers, true}
         ]}
  ]}.

--- a/src/inter_dc_compression_buffer.erl
+++ b/src/inter_dc_compression_buffer.erl
@@ -234,6 +234,21 @@ inter_dc_txn_from_ops(Ops, PrevLogOpId, N, TxId, CommitTime, SnapshotTime) ->
 empty_txns_test() ->
     ?assertEqual(compress([]), none).
 
+noop_test() ->
+    Buffer = [
+        inter_dc_txn_from_ops([{key, bucket, antidote_crdt_orset, [{5, [<<"a">>], []}]},
+                               {key, bucket, antidote_crdt_orset, [{5, [], [<<"a">>]}]}],
+                              0,
+                              1,
+                              2,
+                              300,
+                              250)
+    ],
+    Expected = inter_dc_txn_from_ops([], 0, 3, 2, 300, 250),
+    ?debugFmt("~p~n", [compress(Buffer)]),
+    ?debugFmt("~p~n", [Expected]),
+    ?assertEqual(compress(Buffer), Expected).
+
 orset_test() ->
     Buffer1 = [
         inter_dc_txn_from_ops([{key, bucket, antidote_crdt_orset, [{5, [<<"a">>], []}]}],
@@ -287,6 +302,5 @@ orset_test() ->
         400,
         350
     ),
-    ?debugFmt("~p~n", [compress(Buffer3)]),
     ?assertEqual(compress(Buffer3), Expected3).
 -endif.

--- a/src/inter_dc_compression_buffer.erl
+++ b/src/inter_dc_compression_buffer.erl
@@ -1,0 +1,197 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2017 SyncFree Consortium.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% This module exports functions used for the compression of
+%% operations contained inside lists of transactions.
+
+-module(inter_dc_compression_buffer).
+-include("antidote.hrl").
+-include("inter_dc_repl.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+%% API
+-export([
+    compress/1,
+    compress_and_broadcast/1]).
+
+%% Compresses a list of transactions and then broadcasts the final transaction.
+-spec compress_and_broadcast([#interdc_txn{}]) -> ok.
+compress_and_broadcast(Buffer) ->
+    inter_dc_pub:broadcast(compress(Buffer)).
+
+%% Compresses a list of transactions and returns a single compressed transaction.
+-spec compress([#interdc_txn{}]) -> #interdc_txn{} | none.
+compress([]) -> none;
+compress(Buffer) ->
+    % get the transaction record we will reuse to build the new one (most recent one)
+    Txn = lists:last(Buffer),
+    % TODO: perhaps we should generate a new txid instead of reusing the most recent in the list?
+    %       if this change is applied the log_records in `Commits` must also have their txid changed
+    TxnId = get_txid(Txn),
+    {CompressableOps, ReversedOtherOps} =
+        lists:foldl(fun(#interdc_txn{log_records = Logs}, Acc) ->
+            split_transaction_records(Logs, Acc, TxnId)
+        end, {#{}, []}, Buffer),
+    % compress the operation logs
+    CompressedMapping = maps:map(fun(_, LogRecords) -> compress_log_records(lists:reverse(LogRecords)) end, CompressableOps),
+    % get the prepare and commit log_records from the transaction we are reusing
+    Commits = lists:filter(fun(Record) -> get_log_op_type(Record) =/= update end, Txn#interdc_txn.log_records),
+    % get the prev_log_opid from the earliest transaction in the buffer
+    FstTxn = hd(Buffer),
+    PrevLogOpId = FstTxn#interdc_txn.prev_log_opid,
+    % build a list of all the already compressed operations.
+    Ops = lists:flatten(maps:values(CompressedMapping)),
+    % reverse to get the correct ordering.
+    OtherOps = lists:reverse(ReversedOtherOps),
+    Txn#interdc_txn{log_records = OtherOps ++ Ops ++ Commits, prev_log_opid = PrevLogOpId}.
+
+%%%% Private
+
+%% Grabs the transaction id from an interdc_txn record.
+get_txid(Txn) ->
+    Record = hd(Txn#interdc_txn.log_records),
+    Record#log_record.log_operation#log_operation.tx_id.
+
+%% Splits a collection of #log_record{} into a tuple containing:
+%% - a map of `{Key, Bucket} => [#log_record{}]` for the compressable data types;
+%% - a list of `#log_record{}` for the remaining data types;
+-spec split_transaction_records([#log_record{}], {#{}, [#log_record{}]}, txid()) -> {#{}, [#log_record{}]}.
+split_transaction_records(Logs, {Compressable, Other}, TxId) ->
+  lists:foldl(fun(Log, Acc) -> place_txn_record(Log, Acc, TxId) end, {Compressable, Other}, Logs).
+
+%% Updates the #log_record{} txid and places the #log_record{} into the correct tuple slot.
+-spec place_txn_record(#log_record{}, {#{}, [#log_record{}]}, txid()) -> {#{}, [#log_record{}]}.
+place_txn_record(
+    LogRecordArg = #log_record{
+        log_operation = #log_operation{
+            op_type = OpType,
+            log_payload = LogPayload
+        }
+    },
+    {Compressable, Other},
+    TxId) ->
+    case OpType of
+        update ->
+            % update #log_record txid
+            LogOp = LogRecordArg#log_record.log_operation,
+            LogRecord = LogRecordArg#log_record{
+                log_operation = LogOp#log_operation{
+                    tx_id = TxId
+                }
+            },
+            {Key, Bucket, Type, _Op} = destructure_update_payload(LogPayload),
+            case Type:is_compressable() of
+                true ->
+                    K = {Key, Bucket},
+                    Compressable1 = case maps:is_key(K, Compressable) of
+                        true ->
+                            Current = maps:get(K, Compressable),
+                            maps:put(K, [LogRecord | Current], Compressable);
+                        false -> maps:put(K, [LogRecord], Compressable)
+                    end,
+                    {Compressable1, Other};
+                false -> {Compressable, [LogRecord | Other]}
+            end;
+        _ -> {Compressable, Other}
+    end.
+
+%% Gets the log op type from a #log_record{}.
+-spec get_log_op_type(#log_record{}) -> update | prepare | commit.
+get_log_op_type(#log_record{log_operation = #log_operation{op_type = Type}}) ->
+    Type.
+
+%% Gets the CRDT op() from a #log_record{}.
+-spec get_op(#log_record{}) -> op().
+get_op(#log_record{log_operation = #log_operation{log_payload = #update_log_payload{op = Op}}}) ->
+    Op.
+
+%% Gets the CRDT type() from a #log_record{}.
+-spec get_type(#log_record{}) -> type().
+get_type(#log_record{log_operation = #log_operation{log_payload = #update_log_payload{type = Type}}}) ->
+    Type.
+
+%% Replaces the CRDT op() in the nested #log_record{} with the given op().
+-spec replace_op(#log_record{}, op()) -> #log_record{}.
+replace_op(LogRecord, Op) ->
+    LogOp = LogRecord#log_record.log_operation,
+    LogPayload = LogOp#log_operation.log_payload,
+    LogRecord#log_record{
+        log_operation = LogOp#log_operation{
+            log_payload = LogPayload#update_log_payload{op = Op}
+        }
+    }.
+
+%% Destructures an #update_log_payload{} record to the tuple {key(), bucket(), type(), op()}.
+-spec destructure_update_payload(#update_log_payload{}) -> {key(), bucket(), type(), op()}.
+destructure_update_payload(#update_log_payload{key = Key, bucket = Bucket, type = Type, op = Op}) ->
+    {Key, Bucket, Type, Op}.
+
+%% Compresses the given list of #log_record{} records.
+-spec compress_log_records([#log_record{}]) -> [#log_record{}].
+compress_log_records(LogRecords) ->
+    % This builds a propagation log starting from scratch, adding each #log_record{} one-by-one.
+    % Every time a new record is added using log/2 it attempts to compress the newly added record.
+    lists:reverse(lists:foldl(fun(LogRecord, LogAcc) ->
+        log(LogAcc, LogRecord)
+    end, [], LogRecords)).
+
+%% Adds a #log_record{} to the log and runs the compression.
+-spec log([#log_record{}], #log_record{}) -> [#log_record{}].
+log(LogAcc, LogRecord) ->
+    case log_(LogAcc, LogRecord) of
+        {ok, Logs} -> Logs;
+        {append, Logs, NewLogRecord} -> [NewLogRecord | Logs]
+    end.
+
+%% Helper function for log/2.
+-spec log_([#log_record{}], #log_record{}) -> {ok, [#log_record{}]} | {append, [#log_record{}], #log_record{}}.
+log_([], LogRecord) -> {append, [], LogRecord};
+log_([LogRecord2 | Rest], LogRecord1) ->
+    Type = get_type(LogRecord1),
+    Op1 = get_op(LogRecord1),
+    Op2 = get_op(LogRecord2),
+    case Type:can_compress(Op2, Op1) of
+        true ->
+            case Type:compress_ops(Op2, Op1) of
+                {{noop}, {noop}} -> {ok, Rest};
+                {{noop}, NewOp1} ->
+                    NewRecordOp1 = replace_op(LogRecord1, NewOp1),
+                    log_(Rest, NewRecordOp1);
+                {NewOp2, {noop}} ->
+                    NewRecordOp2 = replace_op(LogRecord2, NewOp2),
+                    {ok, [NewRecordOp2 | Rest]};
+                {NewOp2, NewOp1} ->
+                    NewRecordOp1 = replace_op(LogRecord1, NewOp1),
+                    NewRecordOp2 = replace_op(LogRecord2, NewOp2),
+                    case log_(Rest, NewRecordOp1) of
+                        {ok, List} -> {ok, [NewRecordOp2 | List]};
+                        {append, List, AppendOp} -> {append, [NewRecordOp2 | List], AppendOp}
+                    end
+            end;
+        false ->
+            % Could not compress the two operations, but we can still commmute them.
+            case log_(Rest, LogRecord1) of
+                {ok, List} -> {ok, [LogRecord2 | List]};
+                {append, List, AppendOp} -> {append, [LogRecord2 | List], AppendOp}
+            end
+    end.

--- a/src/inter_dc_compression_buffer.erl
+++ b/src/inter_dc_compression_buffer.erl
@@ -244,9 +244,7 @@ noop_test() ->
                               300,
                               250)
     ],
-    Expected = inter_dc_txn_from_ops([], 0, 3, 2, 300, 250),
-    % ?debugFmt("~p~n", [compress(Buffer)]),
-    % ?debugFmt("~p~n", [Expected]),
+    Expected = inter_dc_txn_from_ops([{key, bucket, antidote_crdt_orset, []}], 0, 2, 2, 300, 250),
     ?assertEqual(compress(Buffer), Expected).
 
 orset_test() ->

--- a/src/inter_dc_compression_buffer.erl
+++ b/src/inter_dc_compression_buffer.erl
@@ -245,8 +245,8 @@ noop_test() ->
                               250)
     ],
     Expected = inter_dc_txn_from_ops([], 0, 3, 2, 300, 250),
-    ?debugFmt("~p~n", [compress(Buffer)]),
-    ?debugFmt("~p~n", [Expected]),
+    % ?debugFmt("~p~n", [compress(Buffer)]),
+    % ?debugFmt("~p~n", [Expected]),
     ?assertEqual(compress(Buffer), Expected).
 
 orset_test() ->

--- a/src/inter_dc_log_sender_vnode.erl
+++ b/src/inter_dc_log_sender_vnode.erl
@@ -101,7 +101,7 @@ init([Partition]) ->
         compression_buffer = [],
         compression_timer = none
     },
-    State1 = case ?OPERATION_COMPRESSION of
+    State1 = case application:get_env(antidote, operation_compression) of
         true -> set_compression_timer(State);
         false -> State
     end,
@@ -125,7 +125,7 @@ handle_command({log_event, LogRecord}, _Sender, State) ->
         %% If the transaction was collected
         {ok, Ops} ->
             Txn = inter_dc_txn:from_ops(Ops, State1#state.partition, State#state.last_log_id),
-            case ?OPERATION_COMPRESSION of
+            case application:get_env(antidote, operation_compression) of
                 true -> buffer(State1, Txn);
                 false -> broadcast(State1, Txn)
             end;
@@ -168,7 +168,7 @@ handoff_starting(_TargetNode, State) ->
     {true, State}.
 handoff_cancelled(State) ->
     State1 = set_timer(State),
-    State2 = case ?OPERATION_COMPRESSION of
+    State2 = case application:get_env(antidote, operation_compression) of
         true -> set_compression_timer(State1);
         false -> State1
     end,
@@ -237,7 +237,7 @@ del_compression_timer(State = #state{compression_timer = Timer}) ->
 %% Cancels the previous compression buffer timer and sets a new one.
 -spec set_compression_timer(#state{}) -> #state{}.
 set_compression_timer(State) ->
-    case ?OPERATION_COMPRESSION of
+    case application:get_env(antidote, operation_compression) of
         true -> set_compression_timer(false, State);
         false -> State
     end.

--- a/src/inter_dc_query_response.erl
+++ b/src/inter_dc_query_response.erl
@@ -99,7 +99,11 @@ get_entries_internal(Partition, From, To) ->
   Txns = lists:map(fun(TxnOps) -> inter_dc_txn:from_ops(TxnOps, Partition, none) end, OpLists),
   %% This is done in order to ensure that we only send the transactions we committed.
   %% We can remove this once the read_log_range is reimplemented.
-  lists:filter(fun inter_dc_txn:is_local/1, Txns).
+  FilteredTxns = lists:filter(fun inter_dc_txn:is_local/1, Txns),
+  case ?OPERATION_COMPRESSION of
+    true -> [inter_dc_compression_buffer:compress(FilteredTxns)];
+    false -> FilteredTxns
+  end.
 
 %% TODO: reimplement this method efficiently once the log provides efficient access by partition and DC (Santiago, here!)
 %% TODO: also fix the method to provide complete snapshots if the log was trimmed

--- a/src/inter_dc_query_response.erl
+++ b/src/inter_dc_query_response.erl
@@ -100,7 +100,7 @@ get_entries_internal(Partition, From, To) ->
   %% This is done in order to ensure that we only send the transactions we committed.
   %% We can remove this once the read_log_range is reimplemented.
   FilteredTxns = lists:filter(fun inter_dc_txn:is_local/1, Txns),
-  case ?OPERATION_COMPRESSION of
+  case application:get_env(antidote, operation_compression) of
     true -> [inter_dc_compression_buffer:compress(FilteredTxns)];
     false -> FilteredTxns
   end.

--- a/src/inter_dc_query_response.erl
+++ b/src/inter_dc_query_response.erl
@@ -101,8 +101,8 @@ get_entries_internal(Partition, From, To) ->
   %% We can remove this once the read_log_range is reimplemented.
   FilteredTxns = lists:filter(fun inter_dc_txn:is_local/1, Txns),
   case application:get_env(antidote, operation_compression) of
-    true -> [inter_dc_compression_buffer:compress(FilteredTxns)];
-    false -> FilteredTxns
+    {ok, true} -> [inter_dc_compression_buffer:compress(FilteredTxns)];
+    {ok, false} -> FilteredTxns
   end.
 
 %% TODO: reimplement this method efficiently once the log provides efficient access by partition and DC (Santiago, here!)


### PR DESCRIPTION
This pull request implements support for operation compression (taken from my non-uniform replication branch).

The basic idea is that when compression is enabled the `inter_dc_log_sender_vnode` will collect committed transactions for the duration specified in `antidote.hrl` instead of immediately broadcasting them. Once the timer ends the transactions are compressed and then broadcasted.

**This pull request depends on SyncFree/antidote_crdt#18**