### PR TITLE
Fix txn readset

### DIFF
--- a/src/clocksi_downstream.erl
+++ b/src/clocksi_downstream.erl
@@ -29,7 +29,7 @@
 -spec generate_downstream_op(Transaction :: tx(), Node :: index_node(), Key :: key(),
   Type :: type(), Update :: op_param(), list()) ->
     {ok, effect()} | {error, atom()}.
-generate_downstream_op(Transaction, IndexNode, Key, Type, Update, WriteSet, InternalReadSet) ->
+generate_downstream_op(Transaction, IndexNode, Key, Type, Update, WriteSet) ->
     %% TODO: Check if read can be omitted for some types as registers
     NeedState = Type:require_state_downstream(Update),
     Result =

--- a/src/clocksi_interactive_coord.erl
+++ b/src/clocksi_interactive_coord.erl
@@ -167,7 +167,7 @@ perform_singleitem_update(Clock, Key, Type, Params, Properties) ->
     %% Execute pre_commit_hook if any
     case antidote_hooks:execute_pre_commit_hook(Key, Type, Params) of
         {Key, Type, Params1} ->
-            case ?CLOCKSI_DOWNSTREAM:generate_downstream_op(Transaction, Partition, Key, Type, Params1, [], []) of
+            case ?CLOCKSI_DOWNSTREAM:generate_downstream_op(Transaction, Partition, Key, Type, Params1, []) of
                 {ok, DownstreamRecord} ->
                     UpdatedPartitions = [{Partition, [{Key, Type, DownstreamRecord}]}],
                     TxId = Transaction#transaction.txn_id,

--- a/src/mock_partition.erl
+++ b/src/mock_partition.erl
@@ -39,7 +39,7 @@
     get_clock_of_dc/2,
     get_preflist_from_key/1,
     read_data_item/5,
-    generate_downstream_op/7,
+    generate_downstream_op/6,
     get_key_partition/1,
     get_logid_from_key/1,
     update_data_item/5,
@@ -146,7 +146,7 @@ read_data_item(_IndexNode, _Transaction, Key, _Type, _Ws) ->
             {ok, mock_value}
     end.
 
-generate_downstream_op(_Transaction, _IndexNode, Key, _Type, _Param, _Ws, _Rs) ->
+generate_downstream_op(_Transaction, _IndexNode, Key, _Type, _Param, _Ws) ->
     case Key of
         downstream_fail ->
             {error, mock_downstream_fail};
@@ -210,4 +210,3 @@ callback_mode() -> state_functions.
 code_change(_OldVsn, StateName, State, _Extra) -> {ok, StateName, State}.
 
 terminate(_Reason, _SN, _SD) -> ok.
-

--- a/test/singledc/clocksi_SUITE.erl
+++ b/test/singledc/clocksi_SUITE.erl
@@ -203,18 +203,18 @@ clocksi_read_write_write_txn_test(Config) ->
     BoundObj = {Key1, antidote_crdt_register_mv, ?BUCKET},
 
     {ok, TxId} = rpc:call(FirstNode, cure, start_transaction, [ignore, []]),
-    check_read_key(FirstNode, Key1, antidote_crdt_register_mv, [], ignore, TxId),
+    antidote_utils:check_read_key(FirstNode, Key1, antidote_crdt_register_mv, [], ignore, TxId),
 
     ok = rpc:call(FirstNode, cure, update_objects, [[{BoundObj, assign, <<"a">>}], TxId]),
     ok = rpc:call(FirstNode, cure, update_objects, [[{BoundObj, assign, <<"b">>}], TxId]),
     ok = rpc:call(FirstNode, cure, update_objects, [[{BoundObj, assign, <<"c">>}], TxId]),
 
-    check_read_key(FirstNode, Key1, antidote_crdt_register_mv, [<<"c">>], ignore, TxId),
+    antidote_utils:check_read_key(FirstNode, Key1, antidote_crdt_register_mv, [<<"c">>], ignore, TxId),
 
     End = rpc:call(FirstNode, cure, commit_transaction, [TxId]),
     ?assertMatch({ok, _CausalSnapshot}, End),
     {ok, CausalSnapshot} = End,
-    check_read_key(FirstNode, Key1, antidote_crdt_register_mv, [<<"c">>], CausalSnapshot, static),
+    antidote_utils:check_read_key(FirstNode, Key1, antidote_crdt_register_mv, [<<"c">>], CausalSnapshot, static),
 
     pass.
 


### PR DESCRIPTION
Transaction coordinator was keeping a readset cache, which is intended to use for following reads/updates with in the same transaction. This readset is not updated consistently which resulted in bug #346. The readset is now removed.