### PR TITLE
Dockerfile for a tiny container image of AntidoteDB based on Alpine Linux

### DIFF
--- a/Dockerfiles/Dockerfile-alpine
+++ b/Dockerfiles/Dockerfile-alpine
@@ -1,4 +1,5 @@
-FROM erlang:19
+# A Docker file for a tiny container image of AntidoteDB based on Alpine Linux
+FROM erlang:20.3.8-alpine
 
 ENV HANDOFF_PORT "8099"
 ENV PB_PORT "8087"
@@ -13,16 +14,18 @@ ENV ANTIDOTE_REPO "https://github.com/AntidoteDB/antidote.git"
 ENV ANTIDOTE_BRANCH "master"
 
 RUN set -xe \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends git openssl ca-certificates \
-  && cd /usr/src \
-  && git clone $ANTIDOTE_REPO \
+  && apk --no-cache --update upgrade busybox musl \
+  && apk --no-cache add bash coreutils git curl build-base openssl ca-certificates perl \
+  && cd /tmp \
+  && git clone ${ANTIDOTE_REPO} \
   && cd antidote \
-  && git checkout $ANTIDOTE_BRANCH \
+  && git checkout ${ANTIDOTE_BRANCH} \
   && make rel \
+  && mkdir /opt \
   && cp -R _build/default/rel/antidote /opt/ \
-  && sed -e '$i,{kernel, [{inet_dist_listen_min, 9100}, {inet_dist_listen_max, 9100}]}' /usr/src/antidote/_build/default/rel/antidote/releases/0.0.1/sys.config > /opt/antidote/releases/0.0.1/sys.config \
-  && rm -rf /usr/src/antidote /var/lib/apt/lists/*
+  && sed -e '$i,{kernel, [{inet_dist_listen_min, 9100}, {inet_dist_listen_max, 9100}]}' /tmp/antidote/_build/default/rel/antidote/releases/0.0.1/sys.config > /opt/antidote/releases/0.0.1/sys.config \
+  && apk del git curl perl \
+  && rm -rf /tmp/antidote /var/lib/apt/lists/*
 
 ADD ./start_and_attach.sh /opt/antidote/
 ADD ./entrypoint.sh /

--- a/Dockerfiles/alpine/Dockerfile
+++ b/Dockerfiles/alpine/Dockerfile
@@ -27,8 +27,8 @@ RUN set -xe \
   && apk del git curl perl \
   && rm -rf /tmp/antidote /var/lib/apt/lists/*
 
-ADD ./start_and_attach.sh /opt/antidote/
-ADD ./entrypoint.sh /
+ADD ../start_and_attach.sh /opt/antidote/
+ADD ../entrypoint.sh /
 
 RUN chmod a+x /opt/antidote/start_and_attach.sh \
   && chmod a+x /entrypoint.sh

--- a/Dockerfiles/alpine/entrypoint.sh
+++ b/Dockerfiles/alpine/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+if [[ ! -f /opt/antidote/releases/0.0.1/setup_ok ]]; then
+  cd /opt/antidote/releases/0.0.1/
+  cp vm.args vm.args_backup
+  if [[ "${SHORT_NAME}" = "true" ]]; then
+    sed "s/-name /-sname /" vm.args_backup > vm.args
+  fi
+  touch setup_ok
+fi
+
+exec "$@"

--- a/Dockerfiles/alpine/start_and_attach.sh
+++ b/Dockerfiles/alpine/start_and_attach.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+NPROC=$(nproc)
+
+if [[ "${NPROC}" -ge 2 ]]; then
+  trap "echo 'Shutting down' && /opt/antidote/bin/env stop" TERM
+  /opt/antidote/bin/env start && sleep 10 && tail -f /opt/antidote/log/console.log & wait ${!}
+else
+  echo "You need at least 2 cpu cores in your Docker (virtual) machine to run this image!"
+  echo "You have ${NPROC} processors"
+  exit 1
+fi


### PR DESCRIPTION
A Dockerfile for a tiny container image (3 times smaller than the default one) of AntidoteDB based on Alpine Linux.

+ This image is used for the Antidote playground
+ Also fixed the Github link in the default Dockerfile