### PR TITLE
Unifying copyrights for antidote and antidote_crdt

### DIFF
--- a/AUTHORS.TXT
+++ b/AUTHORS.TXT
@@ -19,11 +19,12 @@ Mike Rudek
 Roger Pueyo
 Borja
 Shraddha Barke (Technische Universität Kaiserslautern)
-Vitor Enes
+Vitor Enes (Universidade do Minho & INESC TEC, Portugal)
+Georges Younes (Universidade do Minho & INESC TEC, Portugal)
 Goncalo Tomas
 João Neto
 Ilyas Toumlilt
 Paolo Viotti
 Nuno Preguiça (Universidade NOVA de Lisboa, Portugal)
-Carlos Baquero
+Carlos Baquero (Universidade do Minho & INESC TEC, Portugal)
 Marc Shapiro (Université Pierre et Marie Curie / Sorbonne-Université, France)

--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -11,6 +11,7 @@ Technische Universität Kaiserslautern, Germany
 Université Pierre et Marie Curie / Sorbonne-Université, France
 Universidade NOVA de Lisboa, Portugal
 Université catholique de Louvain (UCL), Belgique
+INESC TEC, Portugal 
 >
 
 The list of the contributors to the development of Antidote is given in the AUTHORS file.

--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,7 +1,7 @@
 Antidote Licensing
 ============================================
 
-This file attempts to include all licenses that apply within Antidote (this program) source tree, in particular any that are supposed to be exposed to the end user for credit requirements for instance.
+This file attempts to include all licenses that apply within Antidote (this program) source trees AntidoteDB/antidote and AntidoteDB/antidote_crdt, in particular any that are supposed to be exposed to the end user for credit requirements for instance.
 
 Antidote :A planet scale, highly available, transactional database built on CRDT technology.
 

--- a/src/antidote.erl
+++ b/src/antidote.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/antidote_app.erl
+++ b/src/antidote_app.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/antidote_console.erl
+++ b/src/antidote_console.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/antidote_dc_manager.erl
+++ b/src/antidote_dc_manager.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/antidote_error_monitor.erl
+++ b/src/antidote_error_monitor.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/antidote_hooks.erl
+++ b/src/antidote_hooks.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/antidote_node_event_handler.erl
+++ b/src/antidote_node_event_handler.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/antidote_pb_process.erl
+++ b/src/antidote_pb_process.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/antidote_pb_protocol.erl
+++ b/src/antidote_pb_protocol.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/antidote_ring_event_handler.erl
+++ b/src/antidote_ring_event_handler.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/antidote_stats_collector.erl
+++ b/src/antidote_stats_collector.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/antidote_sup.erl
+++ b/src/antidote_sup.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/bcounter_mgr.erl
+++ b/src/bcounter_mgr.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/binary_utilities.erl
+++ b/src/binary_utilities.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/clocksi_downstream.erl
+++ b/src/clocksi_downstream.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/clocksi_interactive_coord.erl
+++ b/src/clocksi_interactive_coord.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/clocksi_interactive_coord_sup.erl
+++ b/src/clocksi_interactive_coord_sup.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/clocksi_interactive_coord_worker_sup.erl
+++ b/src/clocksi_interactive_coord_worker_sup.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/clocksi_materializer.erl
+++ b/src/clocksi_materializer.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/clocksi_readitem_server.erl
+++ b/src/clocksi_readitem_server.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/clocksi_readitem_sup.erl
+++ b/src/clocksi_readitem_sup.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/clocksi_vnode.erl
+++ b/src/clocksi_vnode.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/cure.erl
+++ b/src/cure.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/dc_meta_data_utilities.erl
+++ b/src/dc_meta_data_utilities.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/dc_utilities.erl
+++ b/src/dc_utilities.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/inter_dc_dep_vnode.erl
+++ b/src/inter_dc_dep_vnode.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/inter_dc_log_sender_vnode.erl
+++ b/src/inter_dc_log_sender_vnode.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/inter_dc_manager.erl
+++ b/src/inter_dc_manager.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/inter_dc_pub.erl
+++ b/src/inter_dc_pub.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/inter_dc_query.erl
+++ b/src/inter_dc_query.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/inter_dc_query_receive_socket.erl
+++ b/src/inter_dc_query_receive_socket.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/inter_dc_query_response.erl
+++ b/src/inter_dc_query_response.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/inter_dc_query_response_sup.erl
+++ b/src/inter_dc_query_response_sup.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/inter_dc_sub.erl
+++ b/src/inter_dc_sub.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/inter_dc_sub_buf.erl
+++ b/src/inter_dc_sub_buf.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/inter_dc_sub_vnode.erl
+++ b/src/inter_dc_sub_vnode.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/inter_dc_txn.erl
+++ b/src/inter_dc_txn.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/log_txn_assembler.erl
+++ b/src/log_txn_assembler.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/log_utilities.erl
+++ b/src/log_utilities.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/logging_vnode.erl
+++ b/src/logging_vnode.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/materializer.erl
+++ b/src/materializer.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/materializer_vnode.erl
+++ b/src/materializer_vnode.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/meta_data_manager.erl
+++ b/src/meta_data_manager.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/meta_data_manager_sup.erl
+++ b/src/meta_data_manager_sup.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/meta_data_sender.erl
+++ b/src/meta_data_sender.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/meta_data_sender_sup.erl
+++ b/src/meta_data_sender_sup.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/mock_partition.erl
+++ b/src/mock_partition.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/stable_meta_data_server.erl
+++ b/src/stable_meta_data_server.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/stable_time_functions.erl
+++ b/src/stable_time_functions.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/vector_orddict.erl
+++ b/src/vector_orddict.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/vectorclock_vnode.erl
+++ b/src/vectorclock_vnode.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/wait_init.erl
+++ b/src/wait_init.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/zmq_context.erl
+++ b/src/zmq_context.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/src/zmq_utils.erl
+++ b/src/zmq_utils.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/multidc/antidote_SUITE.erl
+++ b/test/multidc/antidote_SUITE.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/multidc/append_SUITE.erl
+++ b/test/multidc/append_SUITE.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/multidc/bcountermgr_SUITE.erl
+++ b/test/multidc/bcountermgr_SUITE.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/multidc/clocksi_SUITE.erl
+++ b/test/multidc/clocksi_SUITE.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/multidc/gr_SUITE.erl
+++ b/test/multidc/gr_SUITE.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/multidc/inter_dc_repl_SUITE.erl
+++ b/test/multidc/inter_dc_repl_SUITE.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/multidc/multiple_dcs_SUITE.erl
+++ b/test/multidc/multiple_dcs_SUITE.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/multidc/multiple_dcs_node_failure_SUITE.erl
+++ b/test/multidc/multiple_dcs_node_failure_SUITE.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/singledc/antidote_SUITE.erl
+++ b/test/singledc/antidote_SUITE.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/singledc/append_SUITE.erl
+++ b/test/singledc/append_SUITE.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/singledc/bcountermgr_SUITE.erl
+++ b/test/singledc/bcountermgr_SUITE.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/singledc/clocksi_SUITE.erl
+++ b/test/singledc/clocksi_SUITE.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/singledc/commit_hooks_SUITE.erl
+++ b/test/singledc/commit_hooks_SUITE.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/singledc/gr_SUITE.erl
+++ b/test/singledc/gr_SUITE.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/singledc/log_recovery_SUITE.erl
+++ b/test/singledc/log_recovery_SUITE.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/singledc/object_log_state_SUITE.erl
+++ b/test/singledc/object_log_state_SUITE.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/singledc/pb_client_SUITE.erl
+++ b/test/singledc/pb_client_SUITE.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/utils/antidote_utils.erl
+++ b/test/utils/antidote_utils.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/utils/riak_utils.erl
+++ b/test/utils/riak_utils.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/utils/test_utils.erl
+++ b/test/utils/test_utils.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,

--- a/test/utils/time_utils.erl
+++ b/test/utils/time_utils.erl
@@ -5,6 +5,7 @@
 %%  Université Pierre et Marie Curie / Sorbonne-Université, France
 %%  Universidade NOVA de Lisboa, Portugal
 %%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
 %% >
 %%
 %% This file is provided to you under the Apache License,


### PR DESCRIPTION
The copyrights for source trees AntidoteDB/antidote and AntidoteDB/antidote_crdt are updated and unified on this pull request that also unifies the author list among the two source trees. The additions to the (now common) author list were minimal and might not reflect all commits on the antidote_crdt tree.