### PR TITLE
Modify make command to enable local docker builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,3 @@ xref: compile
 
 dialyzer:
 	${REBAR} dialyzer
-
-docker-build:
-	docker build -f Dockerfiles/Dockerfile -t antidotedb/antidote Dockerfiles
-
-docker-local:
-	docker run --rm -v $(shell pwd):/code -w /code erlang:21 make rel
-	docker build -f Dockerfiles/Dockerfile-local -t antidotedb/antidote:local .


### PR DESCRIPTION
The docker build commands now reside in the `docker-antidote` repository.