### PR TITLE
Use DC manager instead of configuring the test setup manually

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: erlang
 otp_release:
-  - 21.2
+  - 21.3
+  - 22.1
 install:
   - make
   - ./rebar3 update

--- a/test/multidc/antidote_SUITE.erl
+++ b/test/multidc/antidote_SUITE.erl
@@ -98,7 +98,7 @@ dummy_test(Config) ->
 
 
 %% Test that perform NumWrites increments to the key:key1.
-%%      Each increment is sent to a random node of the cluster.
+%%      Each increment is sent to a random node of a random DC.
 %%      Test normal behavior of the antidote
 %%      Performs a read to the first node of the cluster to check whether all the
 %%      increment operations where successfully applied.
@@ -106,7 +106,7 @@ dummy_test(Config) ->
 %%              Nodes: List of the nodes that belong to the built cluster
 random_test(Config) ->
     Bucket = ?BUCKET,
-    Nodes = proplists:get_value(nodes, Config),
+    Nodes = lists:flatten(proplists:get_value(clusters, Config)),
     N = length(Nodes),
 
     % Distribute the updates randomly over all DCs

--- a/test/multidc/antidote_SUITE.erl
+++ b/test/multidc/antidote_SUITE.erl
@@ -44,8 +44,9 @@
 %% tests
 -export([
          dummy_test/1,
-         random_test/1
-        ]).
+         random_test/1,
+         meta_data_env_test/1
+]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -68,7 +69,8 @@ end_per_testcase(Name, _) ->
 all() ->
     [
      dummy_test,
-     random_test
+     random_test,
+     meta_data_env_test
     ].
 
 
@@ -130,3 +132,31 @@ random_test(Config) ->
     Retry = 360000 div Delay, %wait for max 1 min
     ok = time_utils:wait_until_result(G, NumWrites, Retry, Delay),
     pass.
+
+
+%% tests the meta data broadcasting mechanism for environment variables
+meta_data_env_test(Config) ->
+    [[Node1, Node2] | _] = proplists:get_value(clusters, Config),
+    DC = [Node1, Node2],
+
+    %% save old value, each node should have the same value
+    OldValue = rpc:call(Node1, dc_meta_data_utilities, get_env_meta_data, [sync_log, undefined]),
+    OldValue = rpc:call(Node2, dc_meta_data_utilities, get_env_meta_data, [sync_log, undefined]),
+
+    %% turn on sync and check for each node if update was propagated
+    ok = rpc:call(Node1, logging_vnode, set_sync_log, [true]),
+    lists:foreach(fun(Node) ->
+        time_utils:wait_until(fun() -> Value = rpc:call(Node, logging_vnode, is_sync_log, []), Value == true end)
+                  end, DC),
+
+    %% turn off sync and check for each node if update was propagated
+    ok = rpc:call(Node2, logging_vnode, set_sync_log, [false]),
+    lists:foreach(fun(Node) ->
+        time_utils:wait_until(fun() -> Value = rpc:call(Node, logging_vnode, is_sync_log, []), Value == false end)
+                  end, DC),
+
+    %% restore sync and check for each node if update was propagated
+    ok = rpc:call(Node1, logging_vnode, set_sync_log, [OldValue]),
+    lists:foreach(fun(Node) ->
+        time_utils:wait_until(fun() -> Value = rpc:call(Node, logging_vnode, is_sync_log, []), Value == OldValue end)
+                  end, DC).

--- a/test/multidc/pb_client_cluster_management_SUITE.erl
+++ b/test/multidc/pb_client_cluster_management_SUITE.erl
@@ -74,13 +74,13 @@ all() -> [
 setup_cluster_test(Config) ->
     NodeNames = [clusterdev1, clusterdev2, clusterdev3, clusterdev4],
     Nodes = test_utils:pmap(fun(Node) -> test_utils:start_node(Node, Config) end, NodeNames),
-    [Node1, Node2, Node3, Node4] = Nodes,
+    [Node1, Node2, Node3, Node4] = test_utils:unpack(Nodes),
 
     % join cluster 1:
     P1 = spawn_link(fun() ->
         {ok, Pb} = antidotec_pb_socket:start(?ADDRESS, test_utils:web_ports(clusterdev1) + 2),
         ct:pal("joining clusterdev1, clusterdev2"),
- 
+
         Response = antidotec_pb_management:create_dc(Pb, [Node1, Node2]),
         ct:pal("joined clusterdev1, clusterdev2: ~p", [Response]),
         ?assertEqual(ok, Response),

--- a/test/utils/test_utils.erl
+++ b/test/utils/test_utils.erl
@@ -327,12 +327,10 @@ set_up_clusters_common(Config) ->
             connect ->
                 ct:pal("~p of ~p subscribing to other external DCs", [MainNode, unpack(CurrentCluster)]),
 
-                %% get other external DC descriptors
-                OtherDCsToSubscribeTo = lists:filter(fun(Cl) -> Cl /= CurrentCluster end, Clusters),
                 Descriptors = lists:foldl(fun([{_Status, FirstNode} | _], Descriptors) ->
                     {ok, Descriptor} = rpc:call(FirstNode, antidote_dc_manager, get_connection_descriptor, []),
                     Descriptors ++ [Descriptor]
-                                          end, [], OtherDCsToSubscribeTo),
+                                          end, [], Clusters),
 
                 %% subscribe to descriptors of other dcs
                 ok = rpc:call(MainNode, antidote_dc_manager, subscribe_updates_from, [Descriptors])

--- a/test/utils/test_utils.erl
+++ b/test/utils/test_utils.erl
@@ -39,22 +39,13 @@
     bucket/1,
     init_single_dc/2,
     init_multi_dc/2,
-    connect_cluster/1,
     get_node_name/1,
-    descriptors/1,
     web_ports/1,
-    plan_and_commit/1,
-    do_commit/1,
-    try_nodes_ready/3,
-    wait_until_nodes_ready/1,
-    is_ready/1,
-    wait_until_nodes_agree_about_ownership/1,
-    staged_join/2,
     restart_nodes/2,
     partition_cluster/2,
     heal_cluster/2,
-    join_cluster/1,
-    set_up_clusters_common/1
+    set_up_clusters_common/1,
+    unpack/1
 ]).
 
 %% ===========================================
@@ -77,7 +68,7 @@ init_single_dc(Suite, Config) ->
     test_utils:at_init_testsuite(),
 
     StartDCs = fun(Nodes) ->
-        test_utils:pmap(fun(N) -> test_utils:start_node(N, Config) end, Nodes)
+        test_utils:pmap(fun(N) -> {_Status, Node} = test_utils:start_node(N, Config), Node end, Nodes)
                end,
     [Nodes] = test_utils:pmap( fun(N) -> StartDCs(N) end, [[dev1]] ),
     [Node] = Nodes,
@@ -188,10 +179,10 @@ start_node(Name, Config) ->
             {ok, _} = rpc:call(Node, application, ensure_all_started, [antidote]),
             ct:pal("Node ~p started with ports ~p-~p", [Node, Port, Port + 4]),
 
-            Node;
+            {connect, Node};
         {error, already_started, Node} ->
             ct:log("Node ~p already started, reusing node", [Node]),
-            Node;
+            {ready, Node};
         {error, Reason, Node} ->
             ct:pal("Error starting node ~w, reason ~w, will retry", [Node, Reason]),
             ct_slave:stop(Name),
@@ -291,45 +282,6 @@ heal_cluster(ANodes, BNodes) ->
     ok.
 
 
-connect_cluster(Nodes) ->
-  Clusters = [[Node] || Node <- Nodes],
-  ct:log("Connecting DC clusters..."),
-
-  pmap(fun(Cluster) ->
-              Node1 = hd(Cluster),
-              ct:log("Waiting until vnodes start on node ~p", [Node1]),
-              time_utils:wait_until_registered(Node1, inter_dc_pub),
-              time_utils:wait_until_registered(Node1, inter_dc_query_receive_socket),
-              time_utils:wait_until_registered(Node1, inter_dc_query_response_sup),
-              time_utils:wait_until_registered(Node1, inter_dc_query),
-              time_utils:wait_until_registered(Node1, inter_dc_sub),
-              time_utils:wait_until_registered(Node1, meta_data_sender_sup),
-              time_utils:wait_until_registered(Node1, meta_data_manager_sup),
-              ok = rpc:call(Node1, inter_dc_manager, start_bg_processes, [stable_time_functions]),
-              ok = rpc:call(Node1, logging_vnode, set_sync_log, [true])
-          end, Clusters),
-
-    Descriptors = descriptors(Clusters),
-    Res = [ok || _ <- Clusters],
-    pmap(fun(Cluster) ->
-              Node = hd(Cluster),
-              ct:log("Making node ~p observe other DCs...", [Node]),
-              %% It is safe to make the DC observe itself, the observe() call will be ignored silently.
-              Res = rpc:call(Node, inter_dc_manager, observe_dcs_sync, [Descriptors])
-          end, Clusters),
-    pmap(fun(Cluster) ->
-              Node = hd(Cluster),
-              ok = rpc:call(Node, inter_dc_manager, dc_successfully_started, [])
-          end, Clusters),
-    ct:log("DC clusters connected!").
-
-
-descriptors(Clusters) ->
-  lists:map(fun(Cluster) ->
-    {ok, Descriptor} = rpc:call(hd(Cluster), inter_dc_manager, get_descriptor, []),
-    Descriptor
-  end, Clusters).
-
 
 web_ports(dev1) -> 10015;
 web_ports(dev2) -> 10025;
@@ -340,154 +292,55 @@ web_ports(clusterdev2) -> 10125;
 web_ports(clusterdev3) -> 10135;
 web_ports(clusterdev4) -> 10145.
 
-%% Build clusters
-join_cluster(Nodes) ->
-    ct:log("Joining: ~p", [Nodes]),
-    %% Ensure each node owns 100% of it's own ring
-    [?assertEqual([Node], riak_utils:owners_according_to(Node)) || Node <- Nodes],
-    %% Join nodes
-    [Node1|OtherNodes] = Nodes,
-    case OtherNodes of
-        [] ->
-            %% no other nodes, nothing to join/plan/commit
-            ok;
-        _ ->
-            %% ok do a staged join and then commit it, this eliminates the
-            %% large amount of redundant handoff done in a sequential join
-            [staged_join(Node, Node1) || Node <- OtherNodes],
-            plan_and_commit(Node1),
-            try_nodes_ready(Nodes, 3, 500)
-    end,
-
-    ct:log("Wait until nodes read"),
-    ?assertEqual(ok, wait_until_nodes_ready(Nodes)),
-
-    %% Ensure each node owns a portion of the ring
-    ct:log("Wait until agree about ownership"),
-    wait_until_nodes_agree_about_ownership(Nodes),
-
-    ct:log("Wait until no pending changes"),
-    ?assertEqual(ok, riak_utils:wait_until_no_pending_changes(Nodes)),
-
-    ct:log("Wait until ring converged"),
-    riak_utils:wait_until_ring_converged(Nodes),
-
-    ct:log("Check if nodes are fully ready"),
-    time_utils:wait_until(hd(Nodes), fun wait_init:check_ready/1),
-    ok.
-
-
-
-%% @doc Have `Node' send a join request to `PNode'
-staged_join(Node, PNode) ->
-    timer:sleep(100),
-    R = rpc:call(Node, riak_core, staged_join, [PNode]),
-    ct:log("[join] ~p to (~p): ~p", [Node, PNode, R]),
-    ?assertEqual(ok, R),
-    ok.
-
-
-plan_and_commit(Node) ->
-    timer:sleep(100),
-    ct:log("planning and committing cluster join"),
-    case rpc:call(Node, riak_core_claimant, plan, []) of
-        {error, ring_not_ready} ->
-            ct:log("plan: ring not ready"),
-            riak_utils:maybe_wait_for_changes(Node),
-            plan_and_commit(Node);
-        {ok, _, _} ->
-            do_commit(Node)
-    end.
-
-
-do_commit(Node) ->
-    ct:log("Committing"),
-    case rpc:call(Node, riak_core_claimant, commit, []) of
-        {error, plan_changed} ->
-            ct:log("commit: plan changed"),
-            timer:sleep(100),
-            riak_utils:maybe_wait_for_changes(Node),
-            plan_and_commit(Node);
-        {error, ring_not_ready} ->
-            ct:log("commit: ring not ready"),
-            timer:sleep(100),
-            riak_utils:maybe_wait_for_changes(Node),
-            do_commit(Node);
-        {error, nothing_planned} ->
-            %% Assume plan actually committed somehow
-            ok;
-        ok ->
-            ok
-    end
-.
-
-try_nodes_ready([Node1 | _Nodes], 0, _SleepMs) ->
-      ct:log("Nodes not ready after initial plan/commit, retrying"),
-      plan_and_commit(Node1);
-try_nodes_ready(Nodes, N, SleepMs) ->
-  ReadyNodes = [Node || Node <- Nodes, is_ready(Node) =:= true],
-  case ReadyNodes of
-      Nodes ->
-          ok;
-      _ ->
-          try_nodes_ready(Nodes, N-1, SleepMs)
-  end.
-
-
-%% @doc Given a list of nodes, wait until all nodes are considered ready.
-%%      See {@link wait_until_ready/1} for definition of ready.
-wait_until_nodes_ready(Nodes) ->
-    ct:log("Wait until nodes are ready : ~p", [Nodes]),
-    [?assertEqual(ok, time_utils:wait_until(Node, fun is_ready/1)) || Node <- Nodes],
-    ok.
-
-
-%% @private
-is_ready(Node) ->
-    case rpc:call(Node, riak_core_ring_manager, get_raw_ring, []) of
-        {ok, Ring} ->
-            case lists:member(Node, riak_core_ring:ready_members(Ring)) of
-                true -> true;
-                false -> {not_ready, Node}
-            end;
-        Other ->
-            Other
-    end.
-
-
-wait_until_nodes_agree_about_ownership(Nodes) ->
-    ct:log("Wait until nodes agree about ownership ~p", [Nodes]),
-    Results = [ time_utils:wait_until_owners_according_to(Node, Nodes) || Node <- Nodes ],
-    ?assert(lists:all(fun(X) -> ok =:= X end, Results)).
-
 
 %% Build clusters for all test suites.
 set_up_clusters_common(Config) ->
-    ct:log("Building cluster"),
+    ClusterAndDcConfiguration = [[dev1, dev2], [dev3], [dev4]],
 
     StartDCs = fun(Nodes) ->
-                      pmap(fun(N) -> start_node(N, Config) end, Nodes)
+        %% start each node
+        Cl = pmap(fun(N) ->
+            start_node(N, Config)
                   end,
+            Nodes),
+        [{Status, Claimant} | OtherNodes] = Cl,
 
-    Clusters = pmap(
-            fun(N) -> StartDCs(N) end,
-            [[dev1, dev2], [dev3], [dev4]]
-        ),
+        %% check if node was reused or not
+        case Status of
+            ready -> ok;
+            connect ->
+                ct:pal("Creating a ring for claimant ~p and other nodes ~p", [Claimant, unpack(OtherNodes)]),
+                ok = rpc:call(Claimant, antidote_dc_manager, create_dc, [unpack(Cl)])
+        end,
+        Cl
+               end,
+
+    Clusters = pmap(fun(Cluster) ->
+        StartDCs(Cluster)
+                    end, ClusterAndDcConfiguration),
+
+    %% DCs started, but not connected yet
+    pmap(fun([{Status, MainNode} | _] = CurrentCluster) ->
+        case Status of
+            ready -> ok;
+            connect ->
+                ct:pal("~p of ~p subscribing to other external DCs", [MainNode, unpack(CurrentCluster)]),
+
+                %% get other external DC descriptors
+                OtherDCsToSubscribeTo = lists:filter(fun(Cl) -> Cl /= CurrentCluster end, Clusters),
+                Descriptors = lists:foldl(fun([{_Status, FirstNode} | _], Descriptors) ->
+                    {ok, Descriptor} = rpc:call(FirstNode, antidote_dc_manager, get_connection_descriptor, []),
+                    Descriptors ++ [Descriptor]
+                                          end, [], OtherDCsToSubscribeTo),
+
+                %% subscribe to descriptors of other dcs
+                ok = rpc:call(MainNode, antidote_dc_manager, subscribe_updates_from, [Descriptors])
+        end
+         end, Clusters),
 
 
-   [Cluster1, Cluster2, Cluster3] = Clusters,
-   %% Do not join cluster if it is already done
-   case riak_utils:owners_according_to(hd(Cluster1)) of % @TODO this is an adhoc check
-     Cluster1 ->
-         ok; % No need to build Cluster
-     _ ->
-        [join_cluster(Cluster) || Cluster <- Clusters],
-        Clusterheads = [hd(Cluster) || Cluster <- Clusters],
-        connect_cluster(Clusterheads)
-   end,
-
-   ct:log("Cluster joined and connected: ~p  ~p  ~p", [Cluster1, Cluster2, Cluster3]),
-   [Cluster1, Cluster2, Cluster3].
+    ct:log("Clusters joined and data centers connected connected: ~p", [ClusterAndDcConfiguration]),
+    [unpack(DC) || DC <- Clusters].
 
 
 bucket(BucketBaseAtom) ->
@@ -506,8 +359,7 @@ log_config(LogDir) ->
 
     InfoConfig = #{level => info,
         formatter => {logger_formatter, #{single_line => true, max_size => 2048}},
-        config => #{type => {file, filename:join(LogDir, "info.log")}}
-    },
+        config => #{type => {file, filename:join(LogDir, "info.log")}}},
 
     NoticeConfig = #{level => notice,
         formatter => {logger_formatter, #{single_line => true, max_size => 2048}},
@@ -528,3 +380,7 @@ log_config(LogDir) ->
         {handler, warning_antidote, logger_std_h, WarningConfig},
         {handler, error_antidote, logger_std_h, ErrorConfig}
     ].
+
+-spec unpack([{ready | connect, atom()}]) -> [atom()].
+unpack(NodesWithStatus) ->
+    [Node || {_Status, Node} <- NodesWithStatus].

--- a/test/utils/test_utils.erl
+++ b/test/utils/test_utils.erl
@@ -175,6 +175,7 @@ start_node(Name, Config) ->
             %% ANTIDOTE Configuration
             %% reduce number of actual log files created to 4, reduces start-up time of node
             ok = rpc:call(Node, application, set_env, [riak_core, ring_creation_size, 4]),
+            ok = rpc:call(Node, application, set_env, [antidote, sync_log, true]),
 
             {ok, _} = rpc:call(Node, application, ensure_all_started, [antidote]),
             ct:pal("Node ~p started with ports ~p-~p", [Node, Port, Port + 4]),


### PR DESCRIPTION
* Use `antidote_dc_manager` to setup `systests`
* Removed unused code in `test_utils`
* Only create a ring and connect dcs if nodes are started for the first time (can be removed once #396 is fixed) 