### PR TITLE
Add possibility to switch to short names at runtime

### DIFF
--- a/config/vm.args.src
+++ b/config/vm.args.src
@@ -1,5 +1,5 @@
 ## Name of the node
--name ${NODE_NAME}
+-${SHORT_NAME_PREFIX}name ${NODE_NAME}
 
 ## Cookie for distributed erlang
 -setcookie ${COOKIE}


### PR DESCRIPTION
Added environment variable to enable short names via environment variable prefix.
Empty prefix: Use long name
's' prefix: Use short name