### PR TITLE
Improve DC and InterDC Functionality

### DIFF
--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -28,7 +28,14 @@
   {riak_core, [
     %% riak directories
     {ring_state_dir, "${ROOT_DIR_PREFIX}${DATA_DIR_PREFIX}data_riak_core"},
-    {platform_data_dir, "${ROOT_DIR_PREFIX}${DATA_DIR_PREFIX}data_riak_core"}
+    {platform_data_dir, "${ROOT_DIR_PREFIX}${DATA_DIR_PREFIX}data_riak_core"},
+
+    %% determines how many vnodes will be used
+    %% also determines the number of files the log is sliced into
+    %% has to be an exponent of 2
+    %% low number will decrease file accesses (good for testing) and boot time
+    %% high number enables scaling and generates smaller log files
+    {ring_creation_size, 64}
   ]},
 
 

--- a/include/antidote.hrl
+++ b/include/antidote.hrl
@@ -185,7 +185,9 @@
 -type op() :: {op_name(), op_param()}.
 -type effect() :: term().
 
--type dcid() :: 'undefined' | {atom(),tuple()}. %% TODO, is this the only structure that is returned by riak_core_ring:cluster_name(Ring)?
+
+%% DC Id is the riak_core ring cluster name
+-type dcid() :: term().
 -type snapshot_time() :: 'undefined' | vectorclock:vectorclock().
 -type clock_time() :: non_neg_integer().
 -type dc_and_commit_time() :: {dcid(), clock_time()}.

--- a/include/antidote.hrl
+++ b/include/antidote.hrl
@@ -187,7 +187,7 @@
 
 
 %% DC Id is the riak_core ring cluster name
--type dcid() :: term().
+-type dcid() :: undefined | riak_core_ring:riak_core_ring().
 -type snapshot_time() :: 'undefined' | vectorclock:vectorclock().
 -type clock_time() :: non_neg_integer().
 -type dc_and_commit_time() :: {dcid(), clock_time()}.

--- a/rebar.config
+++ b/rebar.config
@@ -100,7 +100,7 @@
         ]}
 ]}.
 
-{relx, [{release, {antidote, "0.2.1"}, [antidote]},
+{relx, [{release, {antidote, "0.2.2"}, [antidote]},
     {dev_mode, false},
     % do not expect Erlang runtime at deployment site
     {include_erts, true},

--- a/src/antidote.app.src
+++ b/src/antidote.app.src
@@ -1,7 +1,7 @@
 %% -*- erlang -*-
 {application, antidote, [
     {description, "A transactional CRDT database"},
-    {vsn, "0.2.1"},
+    {vsn, "0.2.2"},
     {applications, [
         kernel,
         stdlib,

--- a/src/antidote_dc_manager.erl
+++ b/src/antidote_dc_manager.erl
@@ -28,11 +28,22 @@
 
 
 %% This module exports methods to build a data center of multiple nodes and
-%% connect data centers to start replcation among them.
-%%  Usage Example: To create 3 DCs of 2 nodes each:
-%%    create_dc(['antidote@node1', 'antidote@node2']),
-%%    create_dc(['antidote@node3', 'antidote@node4']),
-%%    create_dc(['antidote@node5', 'antidote@node6']),
+%% connect data centers to start replication among them.
+%%
+%%  Usage Example:
+%%
+%%    To create 3 DCs of 2 nodes each execute
+%%
+%%    add_nodes_to_dc(['antidote@node1', 'antidote@node2'])
+%%    add_nodes_to_dc(['antidote@node3', 'antidote@node4'])
+%%    add_nodes_to_dc(['antidote@node5', 'antidote@node6'])
+%%
+%%    on one node of the pair of nodes.
+%%    (Single) Nodes will join the data center of the node the 'add_nodes_to_dc' function is executed on.
+%%    The `add_nodes_to_dc` function is idempotent.
+%%
+%%    To connect these data centers together execute
+%%
 %%    {ok, Descriptor1} = get_connection_descriptor() % on antidote@node1
 %%    {ok, Descriptor2} = get_connection_descriptor() %% on antidote@node3
 %%    {ok, Descriptor3} = get_connection_descriptor() %% on antidote@node5
@@ -47,14 +58,15 @@
 
 -export([
     create_dc/1,
+    add_nodes_to_dc/1,
     get_connection_descriptor/0,
-    subscribe_updates_from/1]
-       ).
+    subscribe_updates_from/1
+]).
 
 
 %% Build a ring of Nodes forming a data center
--spec create_dc([node()]) -> ok | {error, ring_not_ready}.
-create_dc(Nodes) ->
+-spec add_nodes_to_dc([node()]) -> ok | {error, ring_not_ready}.
+add_nodes_to_dc(Nodes) ->
     %% check if ring is ready first
     case riak_core_ring:ring_ready() of
         true -> join_new_nodes(Nodes);
@@ -159,3 +171,7 @@ wait_until_ring_ready(Node) ->
         true -> ok;
         false -> timer:sleep(100), wait_until_ring_ready(Node)
     end.
+
+%% backwards compatible function for add_nodes_to_dc
+-spec create_dc([node()]) -> ok | {error, ring_not_ready}.
+create_dc(Nodes) -> add_nodes_to_dc(Nodes).

--- a/src/antidote_dc_manager.erl
+++ b/src/antidote_dc_manager.erl
@@ -57,12 +57,17 @@
 -include_lib("kernel/include/logger.hrl").
 
 -export([
+    leave_dc/0,
     create_dc/1,
     add_nodes_to_dc/1,
     get_connection_descriptor/0,
     subscribe_updates_from/1
 ]).
 
+
+%% Command this node to leave the current data center
+-spec leave_dc() -> ok | {error, term()}.
+leave_dc() -> riak_core:leave().
 
 %% Build a ring of Nodes forming a data center
 -spec add_nodes_to_dc([node()]) -> ok | {error, ring_not_ready}.

--- a/src/antidote_dc_manager.erl
+++ b/src/antidote_dc_manager.erl
@@ -139,7 +139,7 @@ wait_until_ring_no_pending_changes() ->
     {ok, CurrentRing} = riak_core_ring_manager:get_my_ring(),
     Nodes = riak_core_ring:all_members(CurrentRing),
 
-    ?LOG_NOTICE("Wait until no pending changes on ~p", [Nodes]),
+    ?LOG_DEBUG("Wait until no pending changes on ~p", [Nodes]),
     F = fun() ->
         _ = rpc:multicall(Nodes, riak_core_vnode_manager, force_handoffs, []),
         {Rings, BadNodes} = rpc:multicall(Nodes, riak_core_ring_manager, get_raw_ring, []),

--- a/src/antidote_ring_event_handler.erl
+++ b/src/antidote_ring_event_handler.erl
@@ -32,6 +32,8 @@
 -include("antidote.hrl").
 -include_lib("kernel/include/logger.hrl").
 
+-export([update_status/0]).
+
 %% gen_event callbacks
 -export([init/1, handle_event/2, handle_call/2,
          handle_info/2, terminate/2, code_change/3]).
@@ -46,7 +48,7 @@ handle_event({ring_update, _Ring}, State) ->
     update_status(),
     {ok, State}.
 
-handle_call(_Event, State) ->
+handle_call({periodic_update}, State) ->
     {ok, ok, State}.
 
 handle_info(_Info, State) ->

--- a/src/antidote_ring_event_handler.erl
+++ b/src/antidote_ring_event_handler.erl
@@ -48,7 +48,7 @@ handle_event({ring_update, _Ring}, State) ->
     update_status(),
     {ok, State}.
 
-handle_call({periodic_update}, State) ->
+handle_call(_Event, State) ->
     {ok, ok, State}.
 
 handle_info(_Info, State) ->

--- a/src/antidote_stats.erl
+++ b/src/antidote_stats.erl
@@ -89,6 +89,9 @@ handle_info(periodic_update, State = #state{timer = CheapTimer}) ->
 
     update_dc_count(),
 
+    %% update ring state
+    antidote_ring_event_handler:update_status(),
+
     %% schedule tick if continue
     Timer = erlang:send_after(?INTERVAL, self(), periodic_update),
     {noreply, State#state{timer = Timer}};
@@ -144,7 +147,7 @@ to_microsec({MegaSecs, Secs, MicroSecs}) ->
 
 
 update_dc_count() ->
-    DCs = dc_meta_data_utilities:get_dc_ids(true),
+    DCs = dc_meta_data_utilities:get_dc_descriptors(),
     ?STATS({dc_count, length(DCs)}).
 
 

--- a/src/bcounter_mgr.erl
+++ b/src/bcounter_mgr.erl
@@ -78,13 +78,13 @@ init([]) ->
 %% below 0), operation fails, otherwhise a downstream for the decrement
 %% is generated.
 generate_downstream(Key, {decrement, {V, _}}, BCounter) ->
-    MyDCId = dc_meta_data_utilities:get_my_dc_id(),
+    MyDCId = dc_utilities:get_my_dc_id(),
     gen_server:call(?MODULE, {consume, Key, {decrement, {V, MyDCId}}, BCounter});
 
 %% @doc Processes an increment operation for the bounded counter.
 %% Operation is always safe.
 generate_downstream(_Key, {increment, {Amount, _}}, BCounter) ->
-    MyDCId = dc_meta_data_utilities:get_my_dc_id(),
+    MyDCId = dc_utilities:get_my_dc_id(),
     ?DATA_TYPE:downstream({increment, {Amount, MyDCId}}, BCounter);
 
 %% @doc Processes a trasfer operation between two owners of the
@@ -102,7 +102,7 @@ process_transfer({transfer, TransferOp}) ->
 
 handle_cast({transfer, {Key, Amount, Requester}}, #state{last_transfers=LT}=State) ->
     NewLT = cancel_consecutive_req(LT, ?GRACE_PERIOD),
-    MyDCId = dc_meta_data_utilities:get_my_dc_id(),
+    MyDCId = dc_utilities:get_my_dc_id(),
     case can_process(Key, Requester, NewLT) of
         true ->
             {SKey, Bucket} = Key,
@@ -115,7 +115,7 @@ handle_cast({transfer, {Key, Amount, Requester}}, #state{last_transfers=LT}=Stat
     end.
 
 handle_call({consume, Key, {Op, {Amount, _}}, BCounter}, _From, #state{req_queue=RQ}=State) ->
-    MyDCId = dc_meta_data_utilities:get_my_dc_id(),
+    MyDCId = dc_utilities:get_my_dc_id(),
     case ?DATA_TYPE:generate_downstream_check({Op, Amount}, MyDCId, BCounter, Amount) of
         {error, no_permissions} = FailedResult ->
             Available = ?DATA_TYPE:localPermissions(MyDCId, BCounter),
@@ -166,7 +166,7 @@ queue_request(Key, Amount, RequestsQueue) ->
 request_remote(0, _Key) -> 0;
 
 request_remote(RequiredSum, Key) ->
-    MyDCId = dc_meta_data_utilities:get_my_dc_id(),
+    MyDCId = dc_utilities:get_my_dc_id(),
     {SKey, Bucket} = Key,
     BObj = {SKey, ?DATA_TYPE, Bucket},
     {ok, [Obj], _} = antidote:read_objects(ignore, [], [BObj]),
@@ -194,7 +194,7 @@ do_request(MyDCId, RemoteId, Key, Amount) ->
 
 %% Orders the reservation of each DC, from high to low.
 pref_list(Obj) ->
-    MyDCId = dc_meta_data_utilities:get_my_dc_id(),
+    MyDCId = dc_utilities:get_my_dc_id(),
     OtherDCDescriptors = dc_meta_data_utilities:get_dc_descriptors(),
     OtherDCIds = lists:foldl(fun(#descriptor{dcid=Id}, IdsList) ->
                                      case Id == MyDCId of
@@ -227,7 +227,7 @@ clear_pending_req(LastRequests, Period) ->
                    end , LastRequests).
 
 can_process(Key, Requester, LastTransfers) ->
-    MyDCId = dc_meta_data_utilities:get_my_dc_id(),
+    MyDCId = dc_utilities:get_my_dc_id(),
     case Requester == MyDCId of
         false ->
             case orddict:find({Key, Requester}, LastTransfers) of

--- a/src/clocksi_interactive_coord.erl
+++ b/src/clocksi_interactive_coord.erl
@@ -50,7 +50,7 @@
 -define(LOGGING_VNODE, mock_partition).
 
 -else.
--define(DC_META_UTIL, dc_meta_data_utilities).
+-define(DC_META_UTIL, dc_utilities).
 -define(DC_UTIL, dc_utilities).
 -define(VECTORCLOCK, vectorclock).
 -define(LOG_UTIL, log_utilities).

--- a/src/clocksi_vnode.erl
+++ b/src/clocksi_vnode.erl
@@ -499,7 +499,7 @@ reset_prepared(PreparedTx, [{Key, _Type, _Update} | Rest], TxId, Time, ActiveTxs
 
 commit(Transaction, TxCommitTime, Updates, CommittedTx, State) ->
     TxId = Transaction#transaction.txn_id,
-    DcId = dc_meta_data_utilities:get_my_dc_id(),
+    DcId = dc_utilities:get_my_dc_id(),
     LogRecord = #log_operation{tx_id = TxId,
                 op_type = commit,
                 log_payload = #commit_log_payload{commit_time = {DcId, TxCommitTime},
@@ -635,7 +635,7 @@ check_prepared(_TxId, PreparedTx, Key) ->
 -spec update_materializer([{key(), type(), effect()}], tx(), non_neg_integer()) ->
     ok | error.
 update_materializer(DownstreamOps, Transaction, TxCommitTime) ->
-    DcId = dc_meta_data_utilities:get_my_dc_id(),
+    DcId = dc_utilities:get_my_dc_id(),
     ReversedDownstreamOps = lists:reverse(DownstreamOps),
     UpdateFunction = fun({Key, Type, Op}, AccIn) ->
                          CommittedDownstreamOp =

--- a/src/cure.erl
+++ b/src/cure.erl
@@ -210,7 +210,7 @@ gr_snapshot_obtain(ClientClock, Objects, StateOrValue) ->
     %% GST = scalar stable time
     %% VST = vector stable time with entries for each dc
     {ok, GST, VST} = dc_utilities:get_scalar_stable_time(),
-    DcId = dc_meta_data_utilities:get_my_dc_id(),
+    DcId = dc_utilities:get_my_dc_id(),
     Dt = vectorclock:get(DcId, ClientClock),
     case Dt =< GST of
         true ->

--- a/src/dc_meta_data_utilities.erl
+++ b/src/dc_meta_data_utilities.erl
@@ -101,7 +101,7 @@ get_meta_data_name() ->
     stable_meta_data_server:read_meta_data(meta_data_name).
 
 
-%% Store an external dc descriptor
+%% Store an dc descriptor
 -spec store_dc_descriptors([descriptor()]) -> ok.
 store_dc_descriptors(Descriptors) ->
     MergeFunc = fun(DescList, PrevDict) ->
@@ -111,7 +111,7 @@ store_dc_descriptors(Descriptors) ->
                 end,
     stable_meta_data_server:broadcast_meta_data_merge(external_descriptors, Descriptors, MergeFunc, fun dict:new/0).
 
-%% Gets the list of external dc descriptors
+%% Gets the list of all known dc descriptors
 -spec get_dc_descriptors() -> [descriptor()].
 get_dc_descriptors() ->
     case stable_meta_data_server:read_meta_data(external_descriptors) of
@@ -120,7 +120,9 @@ get_dc_descriptors() ->
                               [Desc | Acc]
                       end, [], Dict);
         error ->
-            []
+            ?LOG_WARNING("Could not read shared meta data for external_descriptors"),
+            %% return self descriptor only
+            [inter_dc_manager:get_descriptor()]
     end.
 
 

--- a/src/dc_meta_data_utilities.erl
+++ b/src/dc_meta_data_utilities.erl
@@ -120,7 +120,7 @@ get_dc_descriptors() ->
                               [Desc | Acc]
                       end, [], Dict);
         error ->
-            ?LOG_WARNING("Could not read shared meta data for external_descriptors"),
+            ?LOG_DEBUG("Could not read shared meta data for external_descriptors"),
             %% return self descriptor only
             [inter_dc_manager:get_descriptor()]
     end.

--- a/src/dc_meta_data_utilities.erl
+++ b/src/dc_meta_data_utilities.erl
@@ -40,19 +40,11 @@
          store_env_meta_data/2,
          store_meta_data_name/1,
          get_meta_data_name/0,
-         get_dc_partitions_detailed/1,
-         get_dc_partitions_dict/1,
-         get_my_dc_id/0,
-         reset_my_dc_id/0,
-         set_dc_partitions/2,
-         get_dc_ids/1,
          get_key/1,
          key_as_integer/1,
          store_dc_descriptors/1,
-         get_dc_descriptors/0,
-         load_partition_meta_data/0,
-         get_num_partitions/0,
-         get_partition_at_index/1]).
+         get_dc_descriptors/0
+         ]).
 
 
 %% Should be called once a DC has successfully started
@@ -108,84 +100,6 @@ store_env_meta_data(Name, Value) ->
 get_meta_data_name() ->
     stable_meta_data_server:read_meta_data(meta_data_name).
 
-%% Returns a tuple of three elements
-%% The first is a dict with all partitions for DCID, with key and value being the partition id
-%% The second is a tuple with all partitions for DCID
-%% The third is an integer telling the number of partitions
--spec get_dc_partitions_detailed(dcid()) -> {dict:dict(), tuple(), non_neg_integer()}.
-get_dc_partitions_detailed(DCID) ->
-    case stable_meta_data_server:read_meta_data({partition_meta_data, DCID}) of
-        {ok, Info} ->
-            Info;
-        error ->
-            ?LOG_ERROR("Error no partitions for dc ~w", [DCID]),
-            {dict:new(), {}, 0}
-    end.
-
-%% Returns a dict with all partitions for DCID, with key and value being the partition id
--spec get_dc_partitions_dict(dcid()) -> dict:dict().
-get_dc_partitions_dict(DCID) ->
-    case stable_meta_data_server:read_meta_data({partition_dict, DCID}) of
-        {ok, Dict} ->
-            Dict;
-        error ->
-            ?LOG_ERROR("Error no partitions for dc ~w", [DCID]),
-            dict:new()
-    end.
-
-%% Returns the id of the local dc
--spec get_my_dc_id() -> dcid().
-get_my_dc_id() ->
-    case stable_meta_data_server:read_meta_data(my_dc) of
-        {ok, DcId} ->
-            DcId;
-        error ->
-            %% Add my DC to the list of DCs since none have been added yet
-            reset_my_dc_id()
-    end.
-
-% Sets the id of the local dc
--spec reset_my_dc_id() -> dcid().
-reset_my_dc_id() ->
-            MyDC = dc_utilities:get_my_dc_id(),
-            ok = stable_meta_data_server:broadcast_meta_data(my_dc, MyDC),
-            ok = stable_meta_data_server:broadcast_meta_data_merge(dc_list_w_me, MyDC, fun ordsets:add_element/2, fun ordsets:new/0),
-            MyDC.
-
-%% Loads all the partitions ids into an ets table stored by
-%% their index
--spec load_partition_meta_data() -> ok.
-load_partition_meta_data() ->
-    {ok, CHBin} = riak_core_ring_manager:get_chash_bin(),
-    PartitionList = chashbin:to_list(CHBin),
-    Length = length(PartitionList),
-    ok = stable_meta_data_server:broadcast_meta_data({part, length}, Length),
-    {_Len, IdPartitionList} = lists:foldl(fun(Partition, {PrevId, Acc}) ->
-                                                  {PrevId + 1, Acc ++ [{{part, PrevId}, Partition}]}
-                                          end, {1, []}, PartitionList),
-    ok = stable_meta_data_server:broadcast_meta_data_list(IdPartitionList).
-
-%% Gets the number of partitions at this DC
--spec get_num_partitions() -> non_neg_integer().
-get_num_partitions() ->
-    case stable_meta_data_server:read_meta_data({part, length}) of
-        {ok, Num} ->
-            Num;
-        error ->
-            ok = load_partition_meta_data(),
-            get_num_partitions()
-    end.
-
-%% Get information about a partition based on it index
--spec get_partition_at_index(non_neg_integer()) -> term().
-get_partition_at_index(Index) ->
-    case stable_meta_data_server:read_meta_data({part, Index}) of
-        {ok, Partition} ->
-            Partition;
-        error ->
-            ok = load_partition_meta_data(),
-            get_partition_at_index(Index)
-    end.
 
 %% Store an external dc descriptor
 -spec store_dc_descriptors([descriptor()]) -> ok.
@@ -209,43 +123,6 @@ get_dc_descriptors() ->
             []
     end.
 
-%% Add information about a DC to the meta_data
--spec set_dc_partitions([partition_id()], dcid()) -> ok.
-set_dc_partitions(PartitionList, DCID) ->
-    NumPartitions = length(PartitionList),
-    PartitionTuple = list_to_tuple(PartitionList),
-    PartitionDict =
-        lists:foldl(fun(Part, Acc) ->
-                            dict:store(Part, Part, Acc)
-                    end, dict:new(), PartitionList),
-    ok = stable_meta_data_server:broadcast_meta_data({partition_meta_data, DCID}, {PartitionDict, PartitionTuple, NumPartitions}),
-    ok = stable_meta_data_server:broadcast_meta_data({partition_dict, DCID}, PartitionDict),
-    %% Add the new one to the list that doesnt include you
-    ok = stable_meta_data_server:broadcast_meta_data_merge(dc_list, DCID, fun ordsets:add_element/2, fun ordsets:new/0),
-    %% Be sure your dc is in the list before adding the new one to the list that includes you
-    _MyDCID = get_my_dc_id(),
-    %% Add the new one to the list that includes you
-    ok = stable_meta_data_server:broadcast_meta_data_merge(dc_list_w_me, DCID, fun ordsets:add_element/2, fun ordsets:new/0).
-
-%% Get an ordered list of all the dc ids
--spec get_dc_ids(boolean()) -> [dcid()].
-get_dc_ids(IncludeSelf) ->
-    case IncludeSelf of
-        true ->
-            case stable_meta_data_server:read_meta_data(dc_list_w_me) of
-                {ok, List} ->
-                    List;
-                error ->
-                    [get_my_dc_id()]
-            end;
-        false ->
-            case stable_meta_data_server:read_meta_data(dc_list) of
-                {ok, List} ->
-                    List;
-                error ->
-                    []
-            end
-    end.
 
 -spec get_key(term()) -> term().
 get_key(Key) when is_binary(Key) ->

--- a/src/dc_utilities.erl
+++ b/src/dc_utilities.erl
@@ -58,13 +58,8 @@
   now_microsec/0,
   now_millisec/0]).
 
+
 %% Returns the ID of the current DC.
-%% This should not be called manually (it is only used the very
-%% first time the DC is started), instead if you need to know
-%% the id of the DC use the following:
-%% dc_meta_data_utilites:get_my_dc_id
-%% The reason is that the dcid can change on fail and restart, but
-%% the original name is stored on disk in the meta_data_utilities
 -spec get_my_dc_id() -> dcid().
 get_my_dc_id() ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
@@ -269,8 +264,8 @@ get_stable_snapshot() ->
                         0 ->
                             {ok, StableSnapshot};
                         _ ->
-                            DCs = dc_meta_data_utilities:get_dc_ids(true),
-                            GST = vectorclock:min_clock(StableSnapshot, DCs),
+                            MembersInDc = dc_utilities:get_my_dc_nodes(),
+                            GST = vectorclock:min_clock(StableSnapshot, MembersInDc),
                             {ok, vectorclock:set_all(GST, StableSnapshot)}
                     end
             end
@@ -301,8 +296,8 @@ get_scalar_stable_time() ->
             Now = dc_utilities:now_microsec() - ?OLD_SS_MICROSEC,
             {ok, Now, StableSnapshot};
         _ ->
-            DCs = dc_meta_data_utilities:get_dc_ids(true),
-            GST = vectorclock:min_clock(StableSnapshot, DCs),
+            MembersInDc = dc_utilities:get_my_dc_nodes(),
+            GST = vectorclock:min_clock(StableSnapshot, MembersInDc),
             {ok, GST, vectorclock:set_all(GST, StableSnapshot)}
     end.
 

--- a/src/inter_dc_dep_vnode.erl
+++ b/src/inter_dc_dep_vnode.erl
@@ -239,7 +239,7 @@ update_clock(State = #state{last_updated = LastUpdated}, DCID, Timestamp) ->
 -spec get_partition_clock(state()) -> vectorclock().
 get_partition_clock(State) ->
   %% Return the vectorclock associated with the current state, but update the local entry with the current timestamp
-  vectorclock:set(dc_meta_data_utilities:get_my_dc_id(), dc_utilities:now_microsec(), State#state.vectorclock).
+  vectorclock:set(dc_utilities:get_my_dc_id(), dc_utilities:now_microsec(), State#state.vectorclock).
 
 %% Utility function: converts the transaction to a list of clocksi_payload ops.
 -spec updates_to_clocksi_payloads(interdc_txn()) -> list(clocksi_payload()).

--- a/src/inter_dc_manager.erl
+++ b/src/inter_dc_manager.erl
@@ -56,7 +56,7 @@ get_descriptor() ->
   Publishers = lists:map(fun(Node) -> rpc:call(Node, inter_dc_pub, get_address_list, []) end, Nodes),
   LogReaders = lists:map(fun(Node) -> rpc:call(Node, inter_dc_query_receive_socket, get_address_list, []) end, Nodes),
   {ok, #descriptor{
-    dcid = dc_meta_data_utilities:get_my_dc_id(),
+    dcid = dc_utilities:get_my_dc_id(),
     partition_num = dc_utilities:get_partitions_num(),
     publishers = Publishers,
     logreaders = LogReaders
@@ -127,9 +127,8 @@ start_bg_processes(MetaDataName) ->
                       ok = rpc:call(Node, dc_utilities, check_registered_global, [stable_meta_data_server:generate_server_name(Node)]),
                       ok = rpc:call(Node, meta_data_sender, start, [MetaDataName])
                   end, Nodes),
+
     %% Load the internal meta-data
-    _MyDCId = dc_meta_data_utilities:reset_my_dc_id(),
-    ok = dc_meta_data_utilities:load_partition_meta_data(),
     ok = dc_meta_data_utilities:store_meta_data_name(MetaDataName),
     %% Start the timers sending the heartbeats
     ?LOG_INFO("Starting heartbeat sender timers"),
@@ -233,7 +232,7 @@ observe_dcs_sync(Descriptors, Nodes) ->
 
 -spec forget_dc(descriptor(), [node()]) -> ok.
 forget_dc(#descriptor{dcid = DCID}, Nodes) ->
-  case DCID == dc_meta_data_utilities:get_my_dc_id() of
+  case DCID == dc_utilities:get_my_dc_id() of
     true -> ok;
     false ->
       ?LOG_INFO("Forgetting DC ~p", [DCID]),
@@ -265,7 +264,7 @@ drop_ping(DropPing) ->
 %% Utils
 
 wait_for_stable_snapshot(DCID, MinValue) ->
-  case DCID == dc_meta_data_utilities:get_my_dc_id() of
+  case DCID == dc_utilities:get_my_dc_id() of
     true -> ok;
     false ->
       {ok, SS} = dc_utilities:get_stable_snapshot(),

--- a/src/inter_dc_manager.erl
+++ b/src/inter_dc_manager.erl
@@ -218,6 +218,7 @@ observe_dcs_sync(Descriptors, Nodes) ->
     DCs = lists:map(fun(DC) ->
                         {observe_dc(DC, Nodes), DC}
                     end, Descriptors),
+
     lists:foreach(fun({Res, Desc = #descriptor{dcid = DCID}}) ->
                       case Res of
                           ok ->
@@ -235,7 +236,7 @@ forget_dc(#descriptor{dcid = DCID}, Nodes) ->
   case DCID == dc_utilities:get_my_dc_id() of
     true -> ok;
     false ->
-      ?LOG_INFO("Forgetting DC ~p", [DCID]),
+      ?LOG_NOTICE("Forgetting DC ~p", [DCID]),
       lists:foreach(fun(Node) -> ok = rpc:call(Node, inter_dc_query, del_dc, [DCID]) end, Nodes),
       lists:foreach(fun(Node) -> ok = rpc:call(Node, inter_dc_sub, del_dc, [DCID]) end, Nodes)
   end.

--- a/src/inter_dc_query_response.erl
+++ b/src/inter_dc_query_response.erl
@@ -72,7 +72,7 @@ init([Num]) ->
 handle_cast({get_entries, BinaryQuery, QueryState}, State) ->
     {read_log, Partition, From, To} = binary_to_term(BinaryQuery),
     Entries = get_entries_internal(Partition, From, To),
-    BinaryResp = term_to_binary({{dc_meta_data_utilities:get_my_dc_id(), Partition}, Entries}),
+    BinaryResp = term_to_binary({{dc_utilities:get_my_dc_id(), Partition}, Entries}),
     BinaryPartition = inter_dc_txn:partition_to_bin(Partition),
     FullResponse = <<BinaryPartition/binary, BinaryResp/binary>>,
     ok = inter_dc_query_receive_socket:send_response(FullResponse, QueryState),

--- a/src/inter_dc_txn.erl
+++ b/src/inter_dc_txn.erl
@@ -62,7 +62,7 @@ from_ops(Ops, Partition, PrevLogOpId) ->
 
 -spec ping(partition_id(), op_number() | none, non_neg_integer()) -> interdc_txn().
 ping(Partition, PrevLogOpId, Timestamp) -> #interdc_txn{
-  dcid = dc_meta_data_utilities:get_my_dc_id(),
+  dcid = dc_utilities:get_my_dc_id(),
   partition = Partition,
   prev_log_opid = PrevLogOpId,
   log_records = [],
@@ -82,7 +82,7 @@ last_log_opid(Txn = #interdc_txn{log_records = Ops, prev_log_opid = LogOpId}) ->
     end.
 
 -spec is_local(interdc_txn()) -> boolean().
-is_local(#interdc_txn{dcid = DCID}) -> DCID == dc_meta_data_utilities:get_my_dc_id().
+is_local(#interdc_txn{dcid = DCID}) -> DCID == dc_utilities:get_my_dc_id().
 
 -spec is_ping(interdc_txn()) -> boolean().
 is_ping(#interdc_txn{log_records = Ops}) -> Ops == [].

--- a/src/logging_vnode.erl
+++ b/src/logging_vnode.erl
@@ -305,7 +305,7 @@ handle_command({get_op_id, DCID, Bucket, Partition}, _Sender, State=#state{op_id
 handle_command({start_timer, undefined}, Sender, State) ->
     handle_command({start_timer, Sender}, Sender, State);
 handle_command({start_timer, Sender}, _, State = #state{partition=Partition, op_id_table=OpIdTable, recovered_vector=MaxVector}) ->
-    MyDCID = dc_meta_data_utilities:get_my_dc_id(),
+    MyDCID = dc_utilities:get_my_dc_id(),
     OpId = get_op_id(OpIdTable, {[Partition], MyDCID}),
     IsReady = try
                   ok = inter_dc_dep_vnode:set_dependency_clock(Partition, MaxVector),
@@ -398,7 +398,7 @@ handle_command({append, LogId, LogOperation, Sync}, _Sender,
     ?STATS(operation_update_internal),
     case get_log_from_map(Map, Partition, LogId) of
         {ok, Log} ->
-            MyDCID = dc_meta_data_utilities:get_my_dc_id(),
+            MyDCID = dc_utilities:get_my_dc_id(),
             %% all operations update the per log, operation id
             OpId = get_op_id(OpIdTable, {LogId, MyDCID}),
             #op_number{local = Local, global = Global} = OpId,
@@ -456,7 +456,7 @@ handle_command({append_group, LogId, LogRecordList, _IsLocal = false, Sync}, _Se
                       op_id_table=OpIdTable,
                       partition=Partition,
                       enable_log_to_disk=EnableLog}=State) ->
-    MyDCID = dc_meta_data_utilities:get_my_dc_id(),
+    MyDCID = dc_utilities:get_my_dc_id(),
     {ErrorList, SuccList, UpdatedLogs} =
         lists:foldl(fun(LogRecordOrg, {AccErr, AccSucc, UpdatedLogs}) ->
                         LogRecord = log_utilities:check_log_record_version(LogRecordOrg),

--- a/test/multidc/antidote_SUITE.erl
+++ b/test/multidc/antidote_SUITE.erl
@@ -95,10 +95,10 @@ shard_count(Config) ->
     [[Node1, Node2], [Node3], [Node4]] = proplists:get_value(clusters, Config),
 
     %% Check sharding count
-    Shards1 = rpc:call(Node1, dc_meta_data_utilities, get_dc_ids, [true]),
-    Shards2 = rpc:call(Node2, dc_meta_data_utilities, get_dc_ids, [true]),
-    Shards3 = rpc:call(Node3, dc_meta_data_utilities, get_dc_ids, [true]),
-    Shards4 = rpc:call(Node4, dc_meta_data_utilities, get_dc_ids, [true]),
+    Shards1 = rpc:call(Node1, dc_utilities, get_my_dc_nodes, []),
+    Shards2 = rpc:call(Node2, dc_utilities, get_my_dc_nodes, []),
+    Shards3 = rpc:call(Node3, dc_utilities, get_my_dc_nodes, []),
+    Shards4 = rpc:call(Node4, dc_utilities, get_my_dc_nodes, []),
 
     ?assertEqual({2,2,1,1}, {length(Shards1), length(Shards2), length(Shards3), length(Shards4)}),
     ok.

--- a/test/utils/test_utils.erl
+++ b/test/utils/test_utils.erl
@@ -311,7 +311,7 @@ set_up_clusters_common(Config) ->
             ready -> ok;
             connect ->
                 ct:pal("Creating a ring for claimant ~p and other nodes ~p", [Claimant, unpack(OtherNodes)]),
-                ok = rpc:call(Claimant, antidote_dc_manager, create_dc, [unpack(Cl)])
+                ok = rpc:call(Claimant, antidote_dc_manager, add_nodes_to_dc, [unpack(Cl)])
         end,
         Cl
                end,


### PR DESCRIPTION
Fixes #396 #400 #399.

* Removed redundant stable meta data for our ring. Contrary to the comment, the riak cluster_name does not change after a fail and restart of a node. This fixes a bug where the meta data was not updated correctly and requests were routed to the wrong node, causing handoffs to be triggered.
* Improved documentation of some functions
* Improved adding nodes to a DC 
  * Rewrote DC creation functions
  * `create_dc` is now deprecated but still available
  * `add_nodes_to_dc` is a better fitting function name. Adding nodes to the dc dynamically should be possible, but not tested yet
* Added test cases for #396 and #400 
* Added test case to check for correct shard count per DC
* `add_nodes_to_dc` is now idempotent