### PR TITLE
Fix riak dynamic join leave

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
     vectorclock,
 
     %% antidote stats module; expose metrics for prometheus as HTTP-API
-    {antidote_stats, {git, "https://github.com/AntidoteDB/antidote_stats", {tag, "v12"}}}
+    {antidote_stats, {git, "https://github.com/AntidoteDB/antidote_stats", {tag, "v13"}}}
 ]}.
 
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -4,7 +4,7 @@
  {<<"antidote_pb_codec">>,{pkg,<<"antidote_pb_codec">>,<<"0.1.2">>},0},
  {<<"antidote_stats">>,
   {git,"https://github.com/AntidoteDB/antidote_stats",
-       {ref,"50fe89a4fc36985a6a5ac4079a92bb9861c2f351"}},
+       {ref,"7c1d82ec3255aabb59a7c23c9f86deec277d034a"}},
   0},
  {<<"antidotec_pb">>,{pkg,<<"antidotec_pb">>,<<"0.2.9">>},0},
  {<<"basho_stats">>,{pkg,<<"basho_stats">>,<<"1.0.3">>},1},

--- a/src/logging_vnode.erl
+++ b/src/logging_vnode.erl
@@ -853,7 +853,8 @@ delete(State = #state{logs_map = _Map, partition = Partition}) ->
     LogId = integer_to_list(Partition) ++ "--" ++ integer_to_list(Partition),
     {ok, DataDir} = application:get_env(antidote, data_dir),
     LogPath = filename:join(DataDir, LogId),
-    file:delete(LogPath ++ ".LOG"),
+    %% best effort delete
+    _ = file:delete(LogPath ++ ".LOG"),
     ?STATS({log_reset, LogPath}),
     {ok, State}.
 

--- a/src/logging_vnode.erl
+++ b/src/logging_vnode.erl
@@ -785,16 +785,30 @@ check_min_time(SnapshotTime, MinSnapshotTime) ->
 check_max_time(SnapshotTime, MaxSnapshotTime) ->
     ((MaxSnapshotTime == undefined) orelse (vectorclock:le(SnapshotTime, MaxSnapshotTime))).
 
-handle_handoff_command(?FOLD_REQ{foldfun = FoldFun, acc0 = Acc0}, _Sender,
+handle_handoff_command(?FOLD_REQ{foldfun = FoldFun, acc0 = OldHandoffState}, _Sender,
                        #state{logs_map = Map, partition = Partition} = State) ->
     ?LOG_DEBUG("Fold request for partition ~p", [Partition]),
-    F = fun({Key, LogRecord}, Acc) -> FoldFun(Key, LogRecord, Acc) end,
-    Acc = join_logs(dict:to_list(Map), F, Acc0),
-    {reply, Acc, State};
 
-handle_handoff_command(Command, _Sender, State) ->
-    ?LOG_INFO("Handoff command ignoring: ~p", [Command]),
-    {noreply, State}.
+    %% VisitElement is called for each element in this vnode's state
+    %% here, just encode a {key, record} pair
+    %% FoldFun will call encode_handoff_item, the arguments should match exactly + 1
+    %% (the Acc argument is handled by riak_core)
+    VisitElement = fun({Key, LogRecord}, HandoffState) -> FoldFun(Key, LogRecord, HandoffState) end,
+
+    NewHandoffState = join_logs(dict:to_list(Map), VisitElement, OldHandoffState),
+    {reply, NewHandoffState, State};
+
+
+%% a vnode in the handoff livecycle stage will not accept handle_commands anymore
+%% instead every command is redirected to the handle_handoff_command implementations
+%% for simplicity, we block every command except the fold handoff itself
+%% for extra availability, every handle_command needs to also be implemented as a handle_handoff_command
+handle_handoff_command(Command, Sender, State) ->
+    ?LOG_NOTICE("Handoff command ~p from ~p, block", [Command, Sender]),
+    {reply, {error, processing_handoff}, State}.
+
+encode_handoff_item(Key, LogRecord) ->
+    term_to_binary({Key, LogRecord}).
 
 handoff_starting(TargetNode, State=#state{partition = Partition}) ->
     ?LOG_INFO("Handoff starting ~p: ~p", [Partition, TargetNode]),
@@ -809,8 +823,6 @@ handoff_finished(TargetNode, State=#state{partition = Partition}) ->
     {ok, State}.
 
 handle_handoff_data(Data, #state{partition = Partition, logs_map = Map, enable_log_to_disk = EnableLog} = State) ->
-%%    ?LOG_NOTICE("Handling handoff data at Partition ~p", [Partition]),
-%%    ?LOG_NOTICE("Data ~p", [binary_to_term(Data)]),
     {LogId, LogRecord} = binary_to_term(Data),
     case get_log_from_map(Map, Partition, LogId) of
         {ok, Log} ->
@@ -822,8 +834,6 @@ handle_handoff_data(Data, #state{partition = Partition, logs_map = Map, enable_l
             {reply, {error, Reason}, State}
     end.
 
-encode_handoff_item(Key, Operation) ->
-    term_to_binary({Key, Operation}).
 
 is_empty(State = #state{logs_map=Map}) ->
     LogIds = dict:fetch_keys(Map),
@@ -834,10 +844,12 @@ is_empty(State = #state{logs_map=Map}) ->
             {false, State}
     end.
 
-delete(State = #state{partition = Partition}) ->
+delete(State = #state{logs_map = _Map, partition = Partition}) ->
     ?LOG_NOTICE("Deleting partition ~p", [Partition]),
-    %% TODO this only works because we do not have intra-dc replication implemented
-    %% re-implement delete for intra-dc replication
+    %% TODO this only works without replication (e.g. N = 1)
+    %% re-implement this and iterate over logs_map to delete all logs belonging to this note,
+    %% not only the primary log
+    %% the format of the primary log is primary_preflist--primary_preflist.LOG
     LogId = integer_to_list(Partition) ++ "--" ++ integer_to_list(Partition),
     {ok, DataDir} = application:get_env(antidote, data_dir),
     LogPath = filename:join(DataDir, LogId),

--- a/src/logging_vnode.erl
+++ b/src/logging_vnode.erl
@@ -801,25 +801,25 @@ handle_handoff_command(?FOLD_REQ{foldfun = FoldFun, acc0 = OldHandoffState}, _Se
 
 %% a vnode in the handoff livecycle stage will not accept handle_commands anymore
 %% instead every command is redirected to the handle_handoff_command implementations
-%% for simplicity, we block every command except the fold handoff itself
+%% for simplicity, we ignore every command except the fold handoff itself
 %% for extra availability, every handle_command needs to also be implemented as a handle_handoff_command
-handle_handoff_command(Command, Sender, State) ->
-    ?LOG_NOTICE("Handoff command ~p from ~p, block", [Command, Sender]),
-    {reply, {error, processing_handoff}, State}.
+handle_handoff_command(Command, _Sender, State) ->
+    ?LOG_INFO("Ignoring command in handoff lifecycle: ~p", [Command]),
+    {noreply, State}.
 
 encode_handoff_item(Key, LogRecord) ->
     term_to_binary({Key, LogRecord}).
 
 handoff_starting(TargetNode, State=#state{partition = Partition}) ->
-    ?LOG_INFO("Handoff starting ~p: ~p", [Partition, TargetNode]),
+    ?LOG_DEBUG("Handoff starting ~p: ~p", [Partition, TargetNode]),
     {true, State}.
 
 handoff_cancelled(State=#state{partition = Partition}) ->
-    ?LOG_INFO("Handoff cancelled: ~p", [Partition]),
+    ?LOG_DEBUG("Handoff cancelled: ~p", [Partition]),
     {ok, State}.
 
 handoff_finished(TargetNode, State=#state{partition = Partition}) ->
-    ?LOG_NOTICE("Handoff finished ~p: ~p", [Partition, TargetNode]),
+    ?LOG_INFO("Handoff finished ~p: ~p", [Partition, TargetNode]),
     {ok, State}.
 
 handle_handoff_data(Data, #state{partition = Partition, logs_map = Map, enable_log_to_disk = EnableLog} = State) ->
@@ -845,7 +845,7 @@ is_empty(State = #state{logs_map=Map}) ->
     end.
 
 delete(State = #state{logs_map = _Map, partition = Partition}) ->
-    ?LOG_NOTICE("Deleting partition ~p", [Partition]),
+    ?LOG_INFO("Deleting partition ~p", [Partition]),
     %% TODO this only works without replication (e.g. N = 1)
     %% re-implement this and iterate over logs_map to delete all logs belonging to this note,
     %% not only the primary log

--- a/test/multidc/pb_client_cluster_management_SUITE.erl
+++ b/test/multidc/pb_client_cluster_management_SUITE.erl
@@ -38,7 +38,8 @@
 
 %% tests
 -export([
-    setup_cluster_test/1
+    setup_cluster_test/1,
+    setup_single_dc_handoff_test/1
 ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -67,9 +68,52 @@ end_per_testcase(Name, _) ->
 
 
 all() -> [
-    setup_cluster_test
+    setup_cluster_test,
+    setup_single_dc_handoff_test
 ].
 
+
+setup_single_dc_handoff_test(Config) ->
+    NodeNames = [clusterdev5, clusterdev6],
+    Nodes = test_utils:pmap(fun(Node) -> test_utils:start_node(Node, Config) end, NodeNames),
+    [Node1, Node2] = test_utils:unpack(Nodes),
+
+    % write counter on clusterdev5:
+    Bucket = ?BUCKET_BIN,
+    Bound_object = {<<"key1">>, antidote_crdt_counter_pn, Bucket},
+    {ok, Pb1} = antidotec_pb_socket:start(?ADDRESS, test_utils:web_ports(clusterdev5) + 2),
+    {ok, TxId4} = antidotec_pb:start_transaction(Pb1, ignore, []),
+    ok = antidotec_pb:update_objects(Pb1, [{Bound_object, increment, 4242}], TxId4),
+    {ok, CommitTime} = antidotec_pb:commit_transaction(Pb1, TxId4),
+    ct:pal("Wrote value to counter"),
+
+    % join cluster:
+    P1 = spawn_link(fun() ->
+        {ok, Pb} = antidotec_pb_socket:start(?ADDRESS, test_utils:web_ports(clusterdev5) + 2),
+        ct:pal("joining clusterdev4, clusterdev5"),
+        Response = antidotec_pb_management:create_dc(Pb, [Node1, Node2]),
+        ct:pal("joined clusterdev4, clusterdev5: ~p", [Response]),
+        ?assertEqual(ok, Response),
+        _Disconnected = antidotec_pb_socket:stop(Pb)
+                    end),
+    wait_for_process(P1),
+
+    {ok, Pb2} = antidotec_pb_socket:start(?ADDRESS, test_utils:web_ports(clusterdev6) + 2),
+
+
+    F = fun() ->
+        % read counter on clusterdev6 (wait for handoff):
+        {ok, TxId1} = antidotec_pb:start_transaction(Pb2, CommitTime, []),
+        {ok, [Counter]} = antidotec_pb:read_objects(Pb2, [Bound_object], TxId1),
+        {ok, _} = antidotec_pb:commit_transaction(Pb2, TxId1),
+        antidotec_counter:value(Counter)
+        end,
+    Delay = 100,
+    Retry = 360000 div Delay, %wait for max 1 min
+    ok = time_utils:wait_until_result(F, 4242, Retry, Delay),
+
+    _Disconnected3 = antidotec_pb_socket:stop(Pb1),
+    _Disconnected3 = antidotec_pb_socket:stop(Pb2).
 
 setup_cluster_test(Config) ->
     NodeNames = [clusterdev1, clusterdev2, clusterdev3, clusterdev4],

--- a/test/multidc/pb_client_cluster_management_SUITE.erl
+++ b/test/multidc/pb_client_cluster_management_SUITE.erl
@@ -80,7 +80,7 @@ setup_single_dc_handoff_test(Config) ->
 
     % write counter on clusterdev5:
     Bucket = ?BUCKET_BIN,
-    Bound_object = {<<"key1">>, antidote_crdt_counter_pn, Bucket},
+    Bound_object = {<<"handoff_test">>, antidote_crdt_counter_pn, Bucket},
     {ok, Pb1} = antidotec_pb_socket:start(?ADDRESS, test_utils:web_ports(clusterdev5) + 2),
     {ok, TxId4} = antidotec_pb:start_transaction(Pb1, ignore, []),
     ok = antidotec_pb:update_objects(Pb1, [{Bound_object, increment, 4242}], TxId4),

--- a/test/utils/test_utils.erl
+++ b/test/utils/test_utils.erl
@@ -291,7 +291,9 @@ web_ports(dev4) -> 10045;
 web_ports(clusterdev1) -> 10115;
 web_ports(clusterdev2) -> 10125;
 web_ports(clusterdev3) -> 10135;
-web_ports(clusterdev4) -> 10145.
+web_ports(clusterdev4) -> 10145;
+web_ports(clusterdev5) -> 10155;
+web_ports(clusterdev6) -> 10165.
 
 
 %% Build clusters for all test suites.


### PR DESCRIPTION
* Implemented delete handoff functionality to remove nodes from a cluster.
  * This does not mean that the interaction with the inter-dc communictation is preserved, this has to be checked separately. Nevertheless, removing a node now works on the `riak_core` side of things.
  * Updated metrics to account for log size decrease
* Added missing function clause for the handoff commands for the `materializer_vnode`
  * Fixes a bug where a function clause is missing during handoff
  * This does not mean the handoff is implemented correctly, unexpected requests coming from processes which try to access the vnode in the `handoff` lifecycle can hang indefinitely because the timeout of riak calls is `infinity`
* Improved documentation for handoff