### PR TITLE
encapsulate usage of ets tables

### DIFF
--- a/include/antidote.hrl
+++ b/include/antidote.hrl
@@ -58,9 +58,6 @@
 %% This is the time that nodes will sleep inbetween sending meta-data
 %% to other physical nodes within the DC
 -define(META_DATA_SLEEP, 1000).
--define(META_TABLE_NAME, a_meta_data_table).
--define(REMOTE_META_TABLE_NAME, a_remote_meta_data_table).
--define(META_TABLE_STABLE_NAME, a_meta_data_table_stable).
 %% Uncomment the following line to use erlang:now()
 %% Otherwise os:timestamp() is used which can go backwards
 %% which is unsafe for clock-si

--- a/src/antidote_ets_meta_data.erl
+++ b/src/antidote_ets_meta_data.erl
@@ -1,0 +1,153 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright <2013-2020> <
+%%  Technische Universität Kaiserslautern, Germany
+%%  Université Pierre et Marie Curie / Sorbonne-Université, France
+%%  Universidade NOVA de Lisboa, Portugal
+%%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
+%% >
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either expressed or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% List of the contributors to the development of Antidote: see AUTHORS file.
+%% Description and complete License: see LICENSE file.
+%% -------------------------------------------------------------------
+-module(antidote_ets_meta_data).
+
+-include("antidote.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kernel/include/logger.hrl").
+
+-define(META_TABLE_NAME, a_meta_data_table).
+-define(REMOTE_META_TABLE_NAME, a_remote_meta_data_table).
+-define(META_DATA_SENDER_TABLE_NAME, a_meta_data_sender_table).
+
+-export([create_meta_data_table/1,
+    create_meta_data_sender_table/1,
+    create_remote_meta_data_table/1,
+    insert_meta_data_sender_merged_data/2,
+    insert_meta_data/3,
+    get_meta_data/3,
+    delete_meta_data_partition/2,
+    get_meta_data_sender_merged_data/2,
+    remote_table_ready/1,
+    get_meta_data_as_map/1,
+    get_remote_meta_data_as_map/1,
+    delete_meta_data_table/1,
+    delete_meta_data_sender_table/1,
+    delete_remote_meta_data_table/1,
+    insert_remote_meta_data/3,
+    insert_remote_meta_data_new/3,
+    delete_remote_meta_data_node/2]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+- spec create_meta_data_table(atom()) -> ets:tab().
+create_meta_data_table(Name) ->
+    ets:new(get_table_name(Name, ?META_TABLE_NAME), [set, named_table, public, ?META_TABLE_CONCURRENCY]).
+
+- spec create_meta_data_sender_table(atom()) -> ets:tab().
+create_meta_data_sender_table(Name) ->
+    ets:new(get_table_name(Name, ?META_DATA_SENDER_TABLE_NAME), [set, named_table, ?META_TABLE_STABLE_CONCURRENCY]).
+
+- spec create_remote_meta_data_table(atom()) -> ets:tab().
+create_remote_meta_data_table(Name) ->
+    ets:new(get_table_name(Name, ?REMOTE_META_TABLE_NAME), [set, named_table, protected, ?META_TABLE_CONCURRENCY]).
+
+- spec insert_meta_data_sender_merged_data(atom(), term()) -> true.
+insert_meta_data_sender_merged_data(Name, Data) ->
+    ets:insert(get_table_name(Name, ?META_DATA_SENDER_TABLE_NAME), {merged_data, Data}).
+
+-spec insert_meta_data(atom(), partition_id(), term()) -> true.
+insert_meta_data(Name, Partition, Data) ->
+    ets:insert(get_table_name(Name, ?META_TABLE_NAME), {Partition, Data}).
+
+%% Get meta data for some partition
+-spec get_meta_data(atom(), partition_id(), X) -> X.
+get_meta_data(Name, Partition, Default) ->
+    case ets:lookup( get_table_name(Name, ?META_TABLE_NAME), Partition) of
+        [] ->
+            Default;
+        [{Partition, Other}] ->
+            Other
+    end.
+
+%% Remove meta data for partition
+-spec delete_meta_data_partition(atom(), partition_id()) -> true.
+delete_meta_data_partition(Name, Partition) ->
+    ets:delete(get_table_name(Name, ?META_TABLE_NAME), Partition).
+
+-spec get_meta_data_sender_merged_data(atom(), X) -> X.
+get_meta_data_sender_merged_data(Name, Default) ->
+    case ets:lookup(get_table_name(Name, ?META_DATA_SENDER_TABLE_NAME), merged_data) of
+        [] ->
+            Default;
+        [{merged_data, Other}] ->
+            Other
+    end.
+
+-spec remote_table_ready(atom()) -> boolean().
+remote_table_ready(Name) ->
+    case ets:info(get_table_name(Name, ?REMOTE_META_TABLE_NAME)) of
+        undefined ->
+            false;
+        _ ->
+            true
+    end.
+
+-spec get_meta_data_as_map(atom()) -> map().
+get_meta_data_as_map(Name) ->
+    maps:from_list(ets:tab2list(get_table_name(Name, ?META_TABLE_NAME))).
+
+-spec get_remote_meta_data_as_map(atom()) ->map().
+get_remote_meta_data_as_map(Name) ->
+    maps:from_list(ets:tab2list(get_table_name(Name, ?REMOTE_META_TABLE_NAME))).
+
+-spec delete_meta_data_table(atom()) -> true.
+delete_meta_data_table(Name) ->
+    ets:delete(get_table_name(Name, ?META_TABLE_NAME)).
+
+-spec delete_meta_data_sender_table(atom()) -> true.
+delete_meta_data_sender_table(Name) ->
+    ets:delete(get_table_name(Name, ?META_DATA_SENDER_TABLE_NAME)).
+
+-spec delete_remote_meta_data_table(atom()) -> true.
+delete_remote_meta_data_table(Name) ->
+    ets:delete(get_table_name(Name, ?REMOTE_META_TABLE_NAME)).
+
+-spec insert_remote_meta_data(ets:tab(), atom(), any()) -> true.
+insert_remote_meta_data(Table, NodeId, Data) ->
+    ets:insert(Table, {NodeId, Data}).
+
+-spec insert_remote_meta_data_new(ets:tab(), atom(), any()) -> true.
+insert_remote_meta_data_new(Table, NodeId, Data) ->
+    ets:insert_new(Table, {NodeId, Data}).
+
+-spec delete_remote_meta_data_node(ets:tab(), atom()) -> true.
+delete_remote_meta_data_node(Table, NodeId) ->
+    ets:delete(Table, NodeId).
+
+
+%%%===================================================================
+%%% Internal Functions
+%%%===================================================================
+
+%% @private
+-spec get_table_name(atom(), atom()) -> atom().
+get_table_name(Name, TableName) ->
+    list_to_atom(atom_to_list(Name) ++ atom_to_list(TableName) ++ atom_to_list(node())).

--- a/src/antidote_ets_meta_data.erl
+++ b/src/antidote_ets_meta_data.erl
@@ -40,7 +40,6 @@
     create_remote_meta_data_table/1,
     insert_meta_data_sender_merged_data/2,
     insert_meta_data/3,
-    get_meta_data/3,
     delete_meta_data_partition/2,
     get_meta_data_sender_merged_data/2,
     remote_table_ready/1,
@@ -77,15 +76,6 @@ insert_meta_data_sender_merged_data(Name, Data) ->
 insert_meta_data(Name, Partition, Data) ->
     ets:insert(get_table_name(Name, ?META_TABLE_NAME), {Partition, Data}).
 
-%% Get meta data for some partition
--spec get_meta_data(atom(), partition_id(), X) -> X.
-get_meta_data(Name, Partition, Default) ->
-    case ets:lookup( get_table_name(Name, ?META_TABLE_NAME), Partition) of
-        [] ->
-            Default;
-        [{Partition, Other}] ->
-            Other
-    end.
 
 %% Remove meta data for partition
 -spec delete_meta_data_partition(atom(), partition_id()) -> true.

--- a/src/antidote_ets_txn_caches.erl
+++ b/src/antidote_ets_txn_caches.erl
@@ -1,0 +1,131 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright <2013-2020> <
+%%  Technische Universität Kaiserslautern, Germany
+%%  Université Pierre et Marie Curie / Sorbonne-Université, France
+%%  Universidade NOVA de Lisboa, Portugal
+%%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
+%% >
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either expressed or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% List of the contributors to the development of Antidote: see AUTHORS file.
+%% Description and complete License: see LICENSE file.
+%% -------------------------------------------------------------------
+%%
+%% prepared_tx table: the prepared txn for each key. Note that for
+%%                    each key, there can be at most one prepared txn in any
+%%                    time.
+
+-module(antidote_ets_txn_caches).
+
+-include("antidote.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kernel/include/logger.hrl").
+
+
+-export([has_prepared_txns_cache/1,
+    get_prepared_txns_by_key/2,
+    get_prepared_txns/1,
+    get_prepared_txn_by_key_and_table/2,
+    create_prepared_txns_cache/1,
+    delete_prepared_txns_cache/1,
+    is_prepared_txn_by_table/2,
+    delete_prepared_txn_by_table/2,
+    insert_prepared_txn_by_table/3,
+    get_prepared_cache_name/1]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec has_prepared_txns_cache(partition_id()) -> boolean().
+has_prepared_txns_cache(Partition) ->
+    case ets:info(get_prepared_cache_name(Partition)) of
+        undefined -> false;
+        _ -> true
+    end.
+
+-spec get_prepared_txns_by_key(partition_id(), key()) -> list().
+get_prepared_txns_by_key(Partition, Key) ->
+    get_prepared_txn_by_key_and_table(get_prepared_cache_name(Partition), Key).
+
+-spec get_prepared_txns(partition_id()) -> list().
+get_prepared_txns(Partition) ->
+    EntryList = ets:tab2list(get_prepared_cache_name(Partition)),
+    lists:flatmap(fun({_, List}) -> List end, EntryList).
+
+-spec get_prepared_txn_by_key_and_table(cache_id(), key()) -> list().
+get_prepared_txn_by_key_and_table(Table, Key) ->
+    case ets:lookup(Table, Key) of
+        [] ->
+            [];
+        [{Key, List}] ->
+            List
+    end.
+
+-spec is_prepared_txn_by_table(cache_id(), key()) -> boolean().
+is_prepared_txn_by_table(Table, Key) ->
+    case ets:lookup(Table, Key) of
+        [] ->
+            true;
+        _ ->
+            false
+    end.
+
+-spec delete_prepared_txn_by_table(cache_id(), key()) -> true.
+delete_prepared_txn_by_table(Table, Key) ->
+    ets:delete(Table, Key).
+
+-spec insert_prepared_txn_by_table(cache_id(), key(), list()) -> true.
+insert_prepared_txn_by_table(Table, Key, List) ->
+    ets:insert(Table, {Key, List}).
+
+-spec create_prepared_txns_cache(partition_id()) -> cache_id().
+create_prepared_txns_cache(Partition) ->
+    case has_prepared_txns_cache(Partition) of
+        false ->
+            ets:new(get_prepared_cache_name(Partition),
+                [set, protected, named_table, ?TABLE_CONCURRENCY]);
+        true ->
+            %% Other vnode hasn't finished closing tables
+            ?LOG_DEBUG("Unable to open ets table in clocksi vnode, retrying"),
+            timer:sleep(100),
+            delete_prepared_txns_cache(Partition),
+            create_prepared_txns_cache(Partition)
+    end.
+
+-spec delete_prepared_txns_cache(partition_id()) -> true.
+delete_prepared_txns_cache(Partition) ->
+    try
+        ets:delete(get_prepared_cache_name(Partition))
+    catch
+        _:Reason ->
+            ?LOG_ERROR("Error closing table ~p", [Reason]),
+            true
+    end.
+
+%%%===================================================================
+%%% Internal Functions
+%%%===================================================================
+
+-spec get_prepared_cache_name(partition_id()) -> cache_id().
+get_prepared_cache_name(Partition) ->
+    get_cache_name(Partition, prepared).
+
+-spec get_cache_name(partition_id(), atom()) -> cache_id().
+get_cache_name(Partition, Base) ->
+    list_to_atom(atom_to_list(node()) ++ atom_to_list(Base) ++ "-" ++ integer_to_list(Partition)).

--- a/src/antidote_ets_txn_caches.erl
+++ b/src/antidote_ets_txn_caches.erl
@@ -39,7 +39,6 @@
 
 -export([has_prepared_txns_cache/1,
     get_prepared_txns_by_key/2,
-    get_prepared_txns/1,
     get_prepared_txn_by_key_and_table/2,
     create_prepared_txns_cache/1,
     delete_prepared_txns_cache/1,
@@ -62,11 +61,6 @@ has_prepared_txns_cache(Partition) ->
 -spec get_prepared_txns_by_key(partition_id(), key()) -> list().
 get_prepared_txns_by_key(Partition, Key) ->
     get_prepared_txn_by_key_and_table(get_prepared_cache_name(Partition), Key).
-
--spec get_prepared_txns(partition_id()) -> list().
-get_prepared_txns(Partition) ->
-    EntryList = ets:tab2list(get_prepared_cache_name(Partition)),
-    lists:flatmap(fun({_, List}) -> List end, EntryList).
 
 -spec get_prepared_txn_by_key_and_table(cache_id(), key()) -> list().
 get_prepared_txn_by_key_and_table(Table, Key) ->

--- a/src/clocksi_vnode.erl
+++ b/src/clocksi_vnode.erl
@@ -36,10 +36,9 @@
 -export([start_vnode/1,
     read_data_item/5,
     async_read_data_item/4,
-    get_cache_name/2,
     send_min_prepared/1,
-    get_active_txns_key/3,
-    get_active_txns/2,
+    get_active_txns_key/2,
+    get_active_txns/1,
     prepare/2,
     commit/3,
     single_commit/2,
@@ -112,55 +111,30 @@ async_read_data_item(Node, TxId, Key, Type) ->
 
 %% @doc Return active transactions in prepare state with their preparetime for a given key
 %% should be run from same physical node
-get_active_txns_key(Key, Partition, TableName) ->
-    case ets:info(TableName) of
-        undefined ->
+get_active_txns_key(Key, Partition) ->
+    case antidote_ets_txn_caches:has_prepared_txns_cache(Partition) of
+        false ->
             riak_core_vnode_master:sync_command({Partition, node()},
                 {get_active_txns, Key},
                 clocksi_vnode_master,
                 infinity);
-        _ ->
-            get_active_txns_key_internal(Key, TableName)
+        true ->
+            {ok, antidote_ets_txn_caches:get_prepared_txns_by_key(Partition, Key)}
     end.
-
-get_active_txns_key_internal(Key, TableName) ->
-    ActiveTxs = case ets:lookup(TableName, Key) of
-                    [] ->
-                        [];
-                    [{Key, List}] ->
-                        List
-                end,
-    {ok, ActiveTxs}.
 
 %% @doc Return active transactions in prepare state with their preparetime for all keys for this partition
 %% should be run from same physical node
-get_active_txns(Partition, TableName) ->
-    case ets:info(TableName) of
-        undefined ->
+get_active_txns(Partition) ->
+    case antidote_ets_txn_caches:has_prepared_txns_cache(Partition) of
+        false ->
             riak_core_vnode_master:sync_command({Partition, node()},
                 {get_active_txns},
                 clocksi_vnode_master,
                 infinity);
-        _ ->
-            get_active_txns_internal(TableName)
+        true ->
+            {ok, antidote_ets_txn_caches:get_prepared_txns(Partition)}
     end.
 
-get_active_txns_internal(TableName) ->
-    ActiveTxs = case ets:tab2list(TableName) of
-                    [] ->
-                        [];
-                    [{Key1, List1} | Rest1] ->
-                        lists:foldl(fun({_Key, List}, Acc) ->
-                            case List of
-                                [] ->
-                                    Acc;
-                                _ ->
-                                    List ++ Acc
-                            end
-                        end,
-                            [], [{Key1, List1} | Rest1])
-                end,
-    {ok, ActiveTxs}.
 
 send_min_prepared(Partition) ->
     dc_utilities:call_local_vnode(Partition, clocksi_vnode_master, {send_min_prepared}).
@@ -209,14 +183,12 @@ abort(ListofNodes, TxId) ->
             ?CLOCKSI_MASTER)
     end, ok, ListofNodes).
 
-get_cache_name(Partition, Base) ->
-    list_to_atom(atom_to_list(node()) ++ atom_to_list(Base) ++ "-" ++ integer_to_list(Partition)).
 
 %% @doc Initializes all data structures that vnode needs to track information
 %%      the transactions it participates on.
 init([Partition]) ->
-    PreparedTx = open_table(Partition),
-    CommittedTx = ets:new(committed_tx, [set]),
+    PreparedTx = antidote_ets_txn_caches:create_prepared_txns_cache(Partition),
+    CommittedTx = create_committed_txns_cache(),
     {ok, #state{partition = Partition,
         prepared_tx = PreparedTx,
         committed_tx = CommittedTx,
@@ -251,34 +223,12 @@ check_table_ready([{Partition, Node} | Rest]) ->
             false
     end.
 
-open_table(Partition) ->
-    case ets:info(get_cache_name(Partition, prepared)) of
-    undefined ->
-        ets:new(get_cache_name(Partition, prepared),
-            [set, protected, named_table, ?TABLE_CONCURRENCY]);
-    _ ->
-        %% Other vnode hasn't finished closing tables
-        ?LOG_DEBUG("Unable to open ets table in clocksi vnode, retrying"),
-        timer:sleep(100),
-        try
-        ets:delete(get_cache_name(Partition, prepared))
-        catch
-        _:_Reason->
-            ok
-        end,
-        open_table(Partition)
-    end.
 
 handle_command({hello}, _Sender, State) ->
   {reply, ok, State};
 
 handle_command({check_tables_ready}, _Sender, SD0 = #state{partition = Partition}) ->
-    Result = case ets:info(get_cache_name(Partition, prepared)) of
-                 undefined ->
-                     false;
-                 _ ->
-                     true
-             end,
+    Result = antidote_ets_txn_caches:has_prepared_txns_cache(Partition),
     {reply, Result, SD0};
 
 handle_command({send_min_prepared}, _Sender,
@@ -382,7 +332,7 @@ handle_command({abort, Transaction, Updates}, _Sender,
 
 handle_command({get_active_txns}, _Sender,
     #state{partition = Partition} = State) ->
-    {reply, get_active_txns_internal(Partition), State};
+    {reply,  {ok, antidote_ets_txn_caches:get_prepared_txns(Partition)}, State};
 
 handle_command(_Message, _Sender, State) ->
     {noreply, State}.
@@ -418,12 +368,7 @@ handle_exit(_Pid, _Reason, State) ->
     {noreply, State}.
 
 terminate(_Reason, #state{partition = Partition} = _State) ->
-    try
-        ets:delete(get_cache_name(Partition, prepared))
-    catch
-        _:Reason ->
-            ?LOG_ERROR("Error closing table ~p", [Reason])
-    end,
+    antidote_ets_txn_caches:delete_prepared_txns_cache(Partition),
     ok.
 
 handle_overload_command(_, _, _) ->
@@ -462,17 +407,12 @@ prepare(Transaction, TxWriteSet, CommittedTx, PreparedTx, PrepareTime, PreparedD
 set_prepared(_PreparedTx, [], _TxId, _Time, Acc) ->
     Acc;
 set_prepared(PreparedTx, [{Key, _Type, _Update} | Rest], TxId, Time, Acc) ->
-    ActiveTxs = case ets:lookup(PreparedTx, Key) of
-                    [] ->
-                        [];
-                    [{Key, List}] ->
-                        List
-                end,
+    ActiveTxs = antidote_ets_txn_caches:get_prepared_txn_by_key_and_table(PreparedTx, Key),
     case lists:keymember(TxId, 1, ActiveTxs) of
         true ->
             set_prepared(PreparedTx, Rest, TxId, Time, Acc);
         false ->
-            true = ets:insert(PreparedTx, {Key, [{TxId, Time} | ActiveTxs]}),
+            true = antidote_ets_txn_caches:insert_prepared_txn_by_table(PreparedTx, Key, [{TxId, Time} | ActiveTxs]),
             set_prepared(PreparedTx, Rest, TxId, Time, dict:append_list(Key, ActiveTxs, Acc))
     end.
 
@@ -480,7 +420,7 @@ reset_prepared(_PreparedTx, [], _TxId, _Time, _ActiveTxs) ->
     ok;
 reset_prepared(PreparedTx, [{Key, _Type, _Update} | Rest], TxId, Time, ActiveTxs) ->
     %% Could do this more efficiently in case of multiple updates to the same key
-    true = ets:insert(PreparedTx, {Key, [{TxId, Time} | dict:fetch(Key, ActiveTxs)]}),
+    true = antidote_ets_txn_caches:insert_prepared_txn_by_table(PreparedTx, Key, [{TxId, Time} | dict:fetch(Key, ActiveTxs)]),
     ?LOG_DEBUG("Inserted preparing txn to PreparedTxns list ~p", [{Key, TxId, Time}]),
     reset_prepared(PreparedTx, Rest, TxId, Time, ActiveTxs).
 
@@ -495,7 +435,7 @@ commit(Transaction, TxCommitTime, Updates, CommittedTx, State) ->
         [{Key, _Type, _Update} | _Rest] ->
         case application:get_env(antidote, txn_cert) of
         {ok, true} ->
-            lists:foreach(fun({K, _, _}) -> true = ets:insert(CommittedTx, {K, TxCommitTime}) end,
+            lists:foreach(fun({K, _, _}) -> true = insert_committed_txn(CommittedTx, K, TxCommitTime) end,
                   Updates);
         _ ->
             ok
@@ -554,18 +494,13 @@ clean_and_notify(TxId, Updates, #state{
 clean_prepared(_PreparedTx, [], _TxId) ->
     ok;
 clean_prepared(PreparedTx, [{Key, _Type, _Update} | Rest], TxId) ->
-    ActiveTxs = case ets:lookup(PreparedTx, Key) of
-                    [] ->
-                        [];
-                    [{Key, List}] ->
-                        List
-                end,
+    ActiveTxs = antidote_ets_txn_caches:get_prepared_txn_by_key_and_table(PreparedTx, Key),
     NewActive = lists:keydelete(TxId, 1, ActiveTxs),
     true = case NewActive of
                [] ->
-                   ets:delete(PreparedTx, Key);
+                   antidote_ets_txn_caches:delete_prepared_txn_by_table(PreparedTx, Key);
                _ ->
-                   ets:insert(PreparedTx, {Key, NewActive})
+                   antidote_ets_txn_caches:insert_prepared_txn_by_table(PreparedTx, Key, NewActive)
            end,
     clean_prepared(PreparedTx, Rest, TxId).
 
@@ -589,8 +524,8 @@ certification_with_check(_, [], _, _) ->
 certification_with_check(TxId, [H | T], CommittedTx, PreparedTx) ->
     TxLocalStartTime = TxId#tx_id.local_start_time,
     {Key, _, _} = H,
-    case ets:lookup(CommittedTx, Key) of
-        [{Key, CommitTime}] ->
+    case get_committed_txn(CommittedTx, Key) of
+        {ok, CommitTime} ->
             case CommitTime > TxLocalStartTime of
                 true ->
                     false;
@@ -602,7 +537,7 @@ certification_with_check(TxId, [H | T], CommittedTx, PreparedTx) ->
                             false
                     end
             end;
-        [] ->
+        not_found ->
             case check_prepared(TxId, PreparedTx, Key) of
                 true ->
                     certification_with_check(TxId, T, CommittedTx, PreparedTx);
@@ -612,12 +547,7 @@ certification_with_check(TxId, [H | T], CommittedTx, PreparedTx) ->
     end.
 
 check_prepared(_TxId, PreparedTx, Key) ->
-    case ets:lookup(PreparedTx, Key) of
-        [] ->
-            true;
-        _ ->
-            false
-    end.
+    antidote_ets_txn_caches:is_prepared_txn_by_table(PreparedTx, Key).
 
 -spec update_materializer([{key(), type(), effect()}], tx(), non_neg_integer()) ->
     ok | error.
@@ -675,6 +605,33 @@ get_time([{Time, TxId} | Rest], TxIdCheck) ->
         false ->
             get_time(Rest, TxIdCheck)
     end.
+
+
+%%%===================================================================
+%%%  Ets tables
+%%%
+%%%  committed_tx_cache: the transaction commit time of the last committed
+%%%                      transaction for each key.
+%%%===================================================================
+
+-spec create_committed_txns_cache() -> cache_id().
+create_committed_txns_cache() ->
+    ets:new(committed_tx, [set]).
+
+-spec insert_committed_txn(cache_id(), key(), clock_time()) -> true.
+insert_committed_txn(CommittedTxCache, Key, TxCommitTime) ->
+    ets:insert(CommittedTxCache, {Key, TxCommitTime}).
+
+-spec get_committed_txn(cache_id(), key()) -> not_found | {ok, clock_time()}.
+get_committed_txn(CommittedTxCache, Key) ->
+    case ets:lookup(CommittedTxCache, Key) of
+        [{_, CommitTime}] ->
+            {ok, CommitTime};
+        [] ->
+            not_found
+    end.
+
+
 
 -ifdef(TEST).
 

--- a/src/dc_utilities.erl
+++ b/src/dc_utilities.erl
@@ -52,7 +52,6 @@
   check_staleness/0,
   check_registered/1,
   get_scalar_stable_time/0,
-  get_partition_snapshot/1,
   get_stable_snapshot/0,
   check_registered_global/1,
   now_microsec/0,
@@ -269,17 +268,6 @@ get_stable_snapshot() ->
                             {ok, vectorclock:set_all(GST, StableSnapshot)}
                     end
             end
-    end.
-
--spec get_partition_snapshot(partition_id()) -> vectorclock:vectorclock().
-get_partition_snapshot(Partition) ->
-    case meta_data_sender:get_meta(stable_time_functions, Partition, vectorclock:new()) of
-        undefined ->
-            %% The partition isn't ready yet, wait for startup
-            timer:sleep(10),
-            get_partition_snapshot(Partition);
-        SS ->
-            SS
     end.
 
 %% Returns the minimum value in the stable vector snapshot time

--- a/src/materializer_vnode.erl
+++ b/src/materializer_vnode.erl
@@ -166,16 +166,11 @@ handle_command({hello}, _Sender, State) ->
   {reply, ok, State};
 
 handle_command({check_ready}, _Sender, State = #state{partition=Partition, is_ready=IsReady}) ->
-    Result = case ets:info(get_cache_name(Partition, ops_cache)) of
-                 undefined ->
+    Result = case has_ops_cache(Partition) of
+                 false ->
                      false;
-                 _ ->
-                     case ets:info(get_cache_name(Partition, snapshot_cache)) of
-                         undefined ->
-                             false;
-                         _ ->
-                             true
-                     end
+                 true ->
+                     has_snapshot_cache(Partition)
              end,
     Result2 = Result and IsReady,
     {reply, Result2, State};
@@ -227,7 +222,7 @@ handle_handoff_command(?FOLD_REQ{foldfun=Fun, acc0=Acc0},
             [Key1|_] = tuple_to_list(Key),
             Fun(Key1, Key, A)
         end,
-    Acc = ets:foldl(F, Acc0, OpsCache),
+    Acc = cache_table_fold(F, Acc0, OpsCache),
     {reply, Acc, State};
 
 handle_handoff_command(Command, _Sender, State) ->
@@ -245,17 +240,17 @@ handoff_finished(_TargetNode, State) ->
 
 handle_handoff_data(Data, State=#state{ops_cache=OpsCache}) ->
     {_Key, Operation} = binary_to_term(Data),
-    true = ets:insert(OpsCache, Operation),
+    true = insert_ops_cache_tuple(OpsCache, Operation),
     {reply, ok, State}.
 
 encode_handoff_item(Key, Operation) ->
     term_to_binary({Key, Operation}).
 
 is_empty(State=#state{ops_cache=OpsCache}) ->
-    case ets:first(OpsCache) of
-        '$end_of_table' ->
+    case cache_is_empty(OpsCache) of
+        true ->
             {true, State};
-        _ ->
+        false ->
             {false, State}
     end.
 
@@ -275,8 +270,8 @@ handle_exit(_Pid, _Reason, State) ->
 
 terminate(_Reason, _State=#state{ops_cache=OpsCache, snapshot_cache=SnapshotCache}) ->
     try
-        ets:delete(OpsCache),
-        ets:delete(SnapshotCache)
+        delete_cache(OpsCache),
+        delete_cache(SnapshotCache)
     catch
         _:_Reason->
             ok
@@ -286,10 +281,6 @@ terminate(_Reason, _State=#state{ops_cache=OpsCache, snapshot_cache=SnapshotCach
 
 
 %%---------------- Internal Functions -------------------%%
-
--spec get_cache_name(non_neg_integer(), atom()) -> atom().
-get_cache_name(Partition, Base) ->
-    list_to_atom(atom_to_list(Base) ++ "-" ++ integer_to_list(Partition)).
 
 -spec load_from_log_to_tables(partition_id(), state()) -> ok | {error, reason()}.
 load_from_log_to_tables(Partition, State) ->
@@ -325,32 +316,12 @@ load_ops(OpsDict, State) ->
                                 end, CommittedOps)
               end, true, OpsDict).
 
--spec open_table(partition_id(), 'ops_cache' | 'snapshot_cache') -> atom() | ets:tid().
-open_table(Partition, Name) ->
-    case ets:info(get_cache_name(Partition, Name)) of
-        undefined ->
-            ets:new(get_cache_name(Partition, Name),
-                [set, protected, named_table, ?TABLE_CONCURRENCY]);
-        _ ->
-            %% Other vnode hasn't finished closing tables
-            ?LOG_DEBUG("Unable to open ets table in materializer vnode, retrying"),
-            timer:sleep(100),
-            try
-                ets:delete(get_cache_name(Partition, Name))
-            catch
-                _:_Reason ->
-                    ok
-            end,
-            open_table(Partition, Name)
-    end.
-
-
 -spec internal_store_ss(key(), materialized_snapshot(), snapshot_time(), boolean(), state()) -> boolean().
 internal_store_ss(Key, Snapshot = #materialized_snapshot{last_op_id = NewOpId}, CommitTime, ShouldGc, State = #state{snapshot_cache=SnapshotCache}) ->
-    SnapshotDict = case ets:lookup(SnapshotCache, Key) of
-                       [] ->
+    SnapshotDict = case get_snapshot_dict(SnapshotCache, Key) of
+                       not_found ->
                            vector_orddict:new();
-                       [{_, SnapshotDictA}] ->
+                       {ok, SnapshotDictA} ->
                            SnapshotDictA
                    end,
     %% Check if this snapshot is newer than the ones already in the cache. Since reads are concurrent multiple
@@ -392,8 +363,8 @@ get_from_snapshot_cache(TxId, Key, Type, MinSnaphsotTime, State = #state{
             ops_cache=OpsCache,
             snapshot_cache=SnapshotCache
         }) ->
-    case ets:lookup(SnapshotCache, Key) of
-        [] ->
+    case get_snapshot_dict(SnapshotCache, Key) of
+        not_found ->
             EmptySnapshot = #materialized_snapshot{
                 last_op_id=0,
                 value=clocksi_materializer:new(Type)
@@ -403,7 +374,7 @@ get_from_snapshot_cache(TxId, Key, Type, MinSnaphsotTime, State = #state{
             BaseVersion = {{ignore, EmptySnapshot}, true},
             update_snapshot_from_cache(BaseVersion, Key, OpsCache);
 
-        [{_, SnapshotDict}] ->
+        {ok, SnapshotDict} ->
             case vector_orddict:get_smaller(MinSnaphsotTime, SnapshotDict) of
                 {undefined, _} ->
                     %% No in-memory snapshot, get it from replication log
@@ -461,12 +432,11 @@ update_snapshot_from_cache(SnapshotResponse, Key, OpsCache) ->
 %%
 -spec fetch_updates_from_cache(cache_id(), key()) -> {[op_and_id()] | tuple(), non_neg_integer()}.
 fetch_updates_from_cache(OpsCache, Key) ->
-    case ets:lookup(OpsCache, Key) of
-        [] ->
+    case get_ops_from_cache(OpsCache, Key) of
+        not_found ->
             {[], 0};
 
-        [Tuple] ->
-            {Key, Length, _OpId, _ListLen, CachedOps} = deconstruct_opscache_entry(Tuple),
+        {ok, {_Key, Length, _OpId, _ListLen, CachedOps}} ->
             {CachedOps, Length}
     end.
 
@@ -533,14 +503,14 @@ snapshot_insert_gc(Key, SnapshotDict, ShouldGc, #state{snapshot_cache = Snapshot
                                          vectorclock:min([CT1, Acc])
                                      end, CT, vector_orddict:to_list(PrunedSnapshots)),
             {Key, Length, OpId, ListLen, OpsDict} =
-                case ets:lookup(OpsCache, Key) of
-                    [] ->
+                case get_ops_from_cache(OpsCache, Key) of
+                    not_found ->
                         {Key, 0, 0, 0, {}};
-                    [Tuple] ->
-                        deconstruct_opscache_entry(Tuple)
+                    {ok, OpsCacheEntry} ->
+                        OpsCacheEntry
                 end,
             {NewLength, PrunedOps} = prune_ops({Length, OpsDict}, CommitTime),
-            true = ets:insert(SnapshotCache, {Key, PrunedSnapshots}),
+            true = insert_snapshot_dict(SnapshotCache, Key, PrunedSnapshots),
             %% Check if the pruned ops are larger or smaller than the previous list size
             %% if so create a larger or smaller list (by dividing or multiplying by 2)
             %% (Another option would be to shrink to a more "minimum" size, but need to test to see what is better)
@@ -564,9 +534,9 @@ snapshot_insert_gc(Key, SnapshotDict, ShouldGc, #state{snapshot_cache = Snapshot
                          end
                      end,
         NewTuple = erlang:make_tuple(?FIRST_OP+NewListLen, 0, [{1, Key}, {2, {NewLength, NewListLen}}, {3, OpId}|PrunedOps]),
-        true = ets:insert(OpsCache, NewTuple);
+        true = insert_ops_cache_tuple(OpsCache, NewTuple);
     false ->
-        true = ets:insert(SnapshotCache, {Key, SnapshotDict})
+        true = insert_snapshot_dict(SnapshotCache, Key, SnapshotDict)
     end.
 
 %% @doc Remove from OpsDict all operations that have committed before Threshold.
@@ -628,14 +598,14 @@ deconstruct_opscache_entry(Tuple) ->
 -spec op_insert_gc(key(), clocksi_payload(), state()) -> true.
 op_insert_gc(Key, DownstreamOp, State = #state{ops_cache = OpsCache}) ->
     %% Check whether there is an ops cache entry for the key
-    case ets:member(OpsCache, Key) of
+    case has_ops_for_key(OpsCache, Key) of
         false ->
-            ets:insert(OpsCache, erlang:make_tuple(?FIRST_OP+?OPS_THRESHOLD, 0, [{1, Key}, {2, {0, ?OPS_THRESHOLD}}]));
+            insert_ops_cache_tuple(OpsCache, erlang:make_tuple(?FIRST_OP+?OPS_THRESHOLD, 0, [{1, Key}, {2, {0, ?OPS_THRESHOLD}}]));
         true ->
             ok
     end,
-    NewId = ets:update_counter(OpsCache, Key, {3, 1}),
-    {Length, ListLen} = ets:lookup_element(OpsCache, Key, 2),
+    NewId = increment_op_id(OpsCache, Key),
+    {Length, ListLen} = get_op_list_length(OpsCache, Key),
 
     %% Perform GC by triggering a read when there are more than OPS_THRESHOLD
     %% operations for a given key or when the list is full
@@ -646,12 +616,119 @@ op_insert_gc(Key, DownstreamOp, State = #state{ops_cache = OpsCache}) ->
             %% Here is where the GC is done (with the 5th argument being "true", GC is performed by the internal read
             {_, _} = internal_read(Key, Type, SnapshotTime, ignore, [], true, State),
             %% Have to obtain again the list/tuple information because the internal_read can change it
-            {NewLength, NewListLen} = ets:lookup_element(OpsCache, Key, 2),
+            {NewLength, NewListLen} = get_op_list_length(OpsCache, Key),
             %% Insert the new op
-            true = ets:update_element(OpsCache, Key, [{NewLength+?FIRST_OP, {NewId, DownstreamOp}}, {2, {NewLength+1, NewListLen}}]);
+            true = update_ops_element(OpsCache, Key, [{NewLength+?FIRST_OP, {NewId, DownstreamOp}}, {2, {NewLength+1, NewListLen}}]);
         false ->
-            true = ets:update_element(OpsCache, Key, [{Length+?FIRST_OP, {NewId, DownstreamOp}}, {2, {Length+1, ListLen}}])
+            true = update_ops_element(OpsCache, Key, [{Length+?FIRST_OP, {NewId, DownstreamOp}}, {2, {Length+1, ListLen}}])
     end.
+
+%%%===================================================================
+%%%  Ets tables
+%%%
+%%%  ops_cache:
+%%%  snapshot_cache:
+%%%===================================================================
+
+-spec get_cache_name(non_neg_integer(), atom()) -> atom().
+get_cache_name(Partition, Base) ->
+    list_to_atom(atom_to_list(Base) ++ "-" ++ integer_to_list(Partition)).
+
+-spec open_table(partition_id(), 'ops_cache' | 'snapshot_cache') -> atom() | cache_id().
+open_table(Partition, Name) ->
+    case ets:info(get_cache_name(Partition, Name)) of
+        undefined ->
+            ets:new(get_cache_name(Partition, Name),
+                [set, protected, named_table, ?TABLE_CONCURRENCY]);
+        _ ->
+            %% Other vnode hasn't finished closing tables
+            ?LOG_DEBUG("Unable to open ets table in materializer vnode, retrying"),
+            timer:sleep(100),
+            try
+                ets:delete(get_cache_name(Partition, Name))
+            catch
+                _:_Reason ->
+                    ok
+            end,
+            open_table(Partition, Name)
+    end.
+
+-spec has_ops_cache(partition_id()) -> boolean().
+has_ops_cache(Partition) ->
+    case ets:info(get_cache_name(Partition, ops_cache)) of
+        undefined ->
+            false;
+        _ ->
+            true
+    end.
+
+-spec has_snapshot_cache(partition_id()) -> boolean().
+has_snapshot_cache(Partition) ->
+    case ets:info(get_cache_name(Partition, snapshot_cache)) of
+        undefined ->
+            false;
+        _ ->
+            true
+    end.
+
+-spec cache_table_fold(fun(), term(), cache_id()) -> term().
+cache_table_fold(F, Acc0, OpsCache) ->
+    ets:foldl(F, Acc0, OpsCache).
+
+-spec insert_ops_cache_tuple(cache_id(), tuple()) -> true.
+insert_ops_cache_tuple(OpsCache, Tuple) ->
+    ets:insert(OpsCache, Tuple).
+
+-spec insert_snapshot_dict(cache_id(), key(), vector_orddict:vector_orddict()) -> true.
+insert_snapshot_dict(SnapshotCache, Key, SnapshotDict) ->
+    ets:insert(SnapshotCache, {Key, SnapshotDict}).
+
+-spec cache_is_empty(cache_id()) -> boolean().
+cache_is_empty(OpsCache) ->
+    case ets:first(OpsCache) of
+        '$end_of_table' ->
+            true;
+        _ ->
+            false
+    end.
+
+-spec delete_cache(cache_id()) -> true.
+delete_cache(Cache) ->
+    ets:delete(Cache).
+
+-spec get_snapshot_dict(cache_id(), key()) -> not_found | {ok, vector_orddict:vector_orddict()}.
+get_snapshot_dict(SnapshotCache, Key) ->
+    case ets:lookup(SnapshotCache, Key) of
+        [] ->
+            not_found;
+        [{Key, SnapshotDictA}] ->
+            {ok, SnapshotDictA}
+    end.
+
+-spec get_ops_from_cache(cache_id(), key()) -> not_found | {ok,{key(), non_neg_integer(), non_neg_integer(), non_neg_integer(), [op_and_id()] | tuple()}}.
+get_ops_from_cache(OpsCache, Key) ->
+    case ets:lookup(OpsCache, Key) of
+        [] ->
+            not_found;
+        [Tuple] ->
+            {ok, deconstruct_opscache_entry(Tuple)}
+    end.
+
+-spec has_ops_for_key(cache_id(), key()) -> boolean().
+has_ops_for_key(OpsCache, Key) ->
+    ets:member(OpsCache, Key).
+
+-spec increment_op_id(cache_id(), key()) -> non_neg_integer().
+increment_op_id(OpsCache, Key) ->
+    ets:update_counter(OpsCache, Key, {3, 1}).
+
+-spec get_op_list_length(cache_id(), key()) -> {non_neg_integer(), non_neg_integer()}.
+get_op_list_length(OpsCache, Key) ->
+    ets:lookup_element(OpsCache, Key, 2).
+
+-spec update_ops_element(cache_id(), key(), [{non_neg_integer(), term()}]) -> boolean().
+update_ops_element(OpsCache, Key, Update) ->
+    ets:update_element(OpsCache, Key, Update).
 
 -ifdef(TEST).
 

--- a/src/materializer_vnode.erl
+++ b/src/materializer_vnode.erl
@@ -705,7 +705,7 @@ get_snapshot_dict(SnapshotCache, Key) ->
             {ok, SnapshotDictA}
     end.
 
--spec get_ops_from_cache(cache_id(), key()) -> not_found | {ok,{key(), non_neg_integer(), non_neg_integer(), non_neg_integer(), [op_and_id()] | tuple()}}.
+-spec get_ops_from_cache(cache_id(), key()) -> not_found | {ok, {key(), non_neg_integer(), non_neg_integer(), non_neg_integer(), [op_and_id()] | tuple()}}.
 get_ops_from_cache(OpsCache, Key) ->
     case ets:lookup(OpsCache, Key) of
         [] ->

--- a/src/meta_data_manager.erl
+++ b/src/meta_data_manager.erl
@@ -76,19 +76,19 @@ add_node(Name, NodeId, Initial) ->
 %% ===================================================================
 
 init([Name]) ->
-    Table = ets:new(meta_data_sender:get_table_name(Name, ?REMOTE_META_TABLE_NAME), [set, named_table, protected, ?META_TABLE_CONCURRENCY]),
+    Table = antidote_ets_meta_data:create_remote_meta_data_table(Name),
     {ok, #state{table = Table}}.
 
 handle_cast({send_meta_data, NodeId, Data}, State = #state{table = Table}) ->
-    true = ets:insert(Table, {NodeId, Data}),
+    true = antidote_ets_meta_data:insert_remote_meta_data(Table, NodeId, Data),
     {noreply, State};
 
 handle_cast({add_node, NodeId, Initial}, State = #state{table = Table}) ->
-    ets:insert_new(Table, {NodeId, Initial}),
+    true = antidote_ets_meta_data:insert_remote_meta_data_new(Table, NodeId, Initial),
     {noreply, State};
 
 handle_cast({remove_node, NodeId}, State = #state{table = Table}) ->
-    ets:delete(Table, NodeId),
+    true = antidote_ets_meta_data:delete_remote_meta_data_node(Table, NodeId),
     {noreply, State};
 
 handle_cast(_Info, State) ->

--- a/src/meta_data_sender.erl
+++ b/src/meta_data_sender.erl
@@ -42,7 +42,6 @@
 -export([start_link/1,
     start/1,
     put_meta/3,
-    get_meta/3,
     get_node_list/0,
     get_node_and_partition_list/0,
     get_merged_data/2,
@@ -110,11 +109,6 @@ get_name(Name) ->
 put_meta(Name, Partition, NewData) ->
     true = antidote_ets_meta_data:insert_meta_data(Name, Partition, NewData),
     ok.
-
-%% Get meta data for some partition
--spec get_meta(atom(), partition_id(), X) -> X.
-get_meta(Name, Partition, Default) ->
-    antidote_ets_meta_data:get_meta_data(Name, Partition, Default).
 
 %% Remove meta data for partition
 -spec remove_partition(atom(), partition_id()) -> ok.

--- a/src/meta_data_sender.erl
+++ b/src/meta_data_sender.erl
@@ -295,7 +295,7 @@ start() ->
     _Table2 = antidote_ets_meta_data:create_meta_data_table(MetaType),
     _Table3 = ets:new(node_table, [set, named_table, public]),
     _Table4 = antidote_ets_meta_data:create_remote_meta_data_table(MetaType),
-    true = antidote_ets_meta_data:insert_meta_data_stable_merged_data(MetaType:initial_merged()),
+    true = antidote_ets_meta_data:insert_meta_data_sender_merged_data(MetaType, MetaType:initial_merged()),
     MetaType.
 
 stop(MetaType) ->

--- a/src/meta_data_sender.erl
+++ b/src/meta_data_sender.erl
@@ -47,7 +47,6 @@
     get_node_and_partition_list/0,
     get_merged_data/2,
     remove_partition/2,
-    get_table_name/2,
     send_meta_data/3,
     callback_mode/0]).
 
@@ -109,45 +108,33 @@ get_name(Name) ->
 %% Insert meta data for some partition
 -spec put_meta(atom(), partition_id(), term()) -> ok.
 put_meta(Name, Partition, NewData) ->
-    MetaTableName = get_table_name(Name, ?META_TABLE_NAME),
-    true = ets:insert(MetaTableName, {Partition, NewData}),
+    true = antidote_ets_meta_data:insert_meta_data(Name, Partition, NewData),
     ok.
 
 %% Get meta data for some partition
 -spec get_meta(atom(), partition_id(), X) -> X.
 get_meta(Name, Partition, Default) ->
-    MetaTableName = get_table_name(Name, ?META_TABLE_NAME),
-    case ets:lookup(MetaTableName, Partition) of
-        [] ->
-            Default;
-        [{Partition, Other}] ->
-            Other
-    end.
+    antidote_ets_meta_data:get_meta_data(Name, Partition, Default).
 
 %% Remove meta data for partition
 -spec remove_partition(atom(), partition_id()) -> ok.
 remove_partition(Name, Partition) ->
-    true = ets:delete(get_table_name(Name, ?META_TABLE_NAME), Partition),
+    true = antidote_ets_meta_data:delete_meta_data_partition(Name, Partition),
     ok.
 
 %% Get merged meta data
 -spec get_merged_data(atom(), X) -> X.
 get_merged_data(Name, Default) ->
-    case ets:lookup(get_table_name(Name, ?META_TABLE_STABLE_NAME), merged_data) of
-        [] ->
-            Default;
-        [{merged_data, Other}] ->
-            Other
-    end.
+    antidote_ets_meta_data:get_meta_data_sender_merged_data(Name, Default).
 
 %% ===================================================================
 %% gen_statem callbacks
 %% ===================================================================
 
 init([Name]) ->
-    _MetaTable = ets:new(get_table_name(Name, ?META_TABLE_STABLE_NAME), [set, named_table, ?META_TABLE_STABLE_CONCURRENCY]),
-    _StableTable = ets:new(get_table_name(Name, ?META_TABLE_NAME), [set, named_table, public, ?META_TABLE_CONCURRENCY]),
-    true = ets:insert(get_table_name(Name, ?META_TABLE_STABLE_NAME), {merged_data, Name:initial_merged()}),
+    _MetaTable = antidote_ets_meta_data:create_meta_data_table(Name),
+    _StableTable = antidote_ets_meta_data:create_meta_data_sender_table(Name),
+    true = antidote_ets_meta_data:insert_meta_data_sender_merged_data(Name, Name:initial_merged()),
     {ok, send_meta_data, #state{last_result = Name:initial_local(),
                                 name = Name,
                                 should_check_nodes = true}}.
@@ -177,7 +164,7 @@ send_meta_data(cast, timeout, State = #state{last_result = LastResult,
                 true ->
                     %% update changed counter for this metadata type
                     %?STATS({metadata_updated, Name}),
-                    true = ets:insert(get_table_name(Name, ?META_TABLE_STABLE_NAME), {merged_data, NewResult}),
+                    true = antidote_ets_meta_data:insert_meta_data_sender_merged_data(Name, NewResult),
                     NewResult;
                 false ->
                     LastResult
@@ -199,12 +186,7 @@ terminate(_Reason, _SN, _SD) -> ok.
 %% @private
 -spec remote_table_ready(atom()) -> boolean().
 remote_table_ready(Name) ->
-    case ets:info(get_table_name(Name, ?REMOTE_META_TABLE_NAME)) of
-        undefined ->
-            false;
-        _ ->
-            true
-    end.
+    antidote_ets_meta_data:remote_table_ready(Name).
 
 %% @private
 -spec update(atom(), map(), [atom()], fun((atom(), atom(), T) -> any()), fun((atom(), atom()) -> any()), T) -> map().
@@ -233,8 +215,8 @@ get_merged_meta_data(Name, CheckNodes) ->
             not_ready;
         true ->
             {NodeList, PartitionList, WillChange} = ?GET_NODE_AND_PARTITION_LIST(),
-            Remote = maps:from_list(ets:tab2list(get_table_name(Name, ?REMOTE_META_TABLE_NAME))),
-            Local = maps:from_list(ets:tab2list(get_table_name(Name, ?META_TABLE_NAME))),
+            Remote = antidote_ets_meta_data:get_remote_meta_data_as_map(Name),
+            Local = antidote_ets_meta_data:get_meta_data_as_map(Name),
             %% Be sure that you are only checking active nodes
             %% This isn't the most efficient way to do this because are checking the list
             %% of nodes and partitions every time to see if any have been removed/added
@@ -288,10 +270,6 @@ get_node_and_partition_list() ->
     Resize = true,
     {NodeList, PartitionList, Resize}.
 
-%% @private
--spec get_table_name(atom(), atom()) -> atom().
-get_table_name(Name, TableName) ->
-    list_to_atom(atom_to_list(Name) ++ atom_to_list(TableName) ++ atom_to_list(node())).
 
 -ifdef(TEST).
 
@@ -313,18 +291,18 @@ meta_data_sender_test_() ->
 
 start() ->
     MetaType = stable_time_functions,
-    _Table  = ets:new(get_table_name(MetaType, ?META_TABLE_STABLE_NAME), [set, named_table, ?META_TABLE_STABLE_CONCURRENCY]),
-    _Table2 = ets:new(get_table_name(MetaType, ?META_TABLE_NAME), [set, named_table, public, ?META_TABLE_CONCURRENCY]),
+    _Table  = antidote_ets_meta_data:create_meta_data_sender_table(MetaType),
+    _Table2 = antidote_ets_meta_data:create_meta_data_table(MetaType),
     _Table3 = ets:new(node_table, [set, named_table, public]),
-    _Table4 = ets:new(get_table_name(MetaType, ?REMOTE_META_TABLE_NAME), [set, named_table, protected, ?META_TABLE_CONCURRENCY]),
-    true = ets:insert(get_table_name(MetaType, ?META_TABLE_STABLE_NAME), {merged_data, MetaType:initial_merged()}),
+    _Table4 = antidote_ets_meta_data:create_remote_meta_data_table(MetaType),
+    true = antidote_ets_meta_data:insert_meta_data_stable_merged_data(MetaType:initial_merged()),
     MetaType.
 
 stop(MetaType) ->
-    true = ets:delete(get_table_name(MetaType, ?META_TABLE_STABLE_NAME)),
-    true = ets:delete(get_table_name(MetaType, ?META_TABLE_NAME)),
+    true = antidote_ets_meta_data:delete_meta_data_table(MetaType),
+    true = antidote_ets_meta_data:delete_meta_data_sender_table(MetaType),
     true = ets:delete(node_table),
-    true = ets:delete(get_table_name(MetaType, ?REMOTE_META_TABLE_NAME)),
+    true = antidote_ets_meta_data:delete_remote_meta_data_table(MetaType),
     ok.
 
 -spec set_nodes_and_partitions_and_willchange([node()], [partition_id()], boolean()) -> ok.


### PR DESCRIPTION
Referred to issue #391 

Encapsulate usage of ets tables by accessing throw api like functions to make clear what is stored,
move ets tables used by multiple modules to there own modules