### PR TITLE
cleaning up calls to lists:foldl

### DIFF
--- a/src/antidote_ring_event_handler.erl
+++ b/src/antidote_ring_event_handler.erl
@@ -49,12 +49,8 @@ handle_event({ring_update, _}, State) ->
     {Claimant, RingReady, Down, MarkedDown, Changes} = riak_core_status:ring_status(),
     ?LOG_NOTICE("Ring is changing!\nClaimant: ~p\nReady: ~p\nNodes down: ~p\nMarked down: ~p\nChanges: ~p\nClaimed: ~p\nPending: ~p", [
         Claimant, RingReady, Down, MarkedDown, length(Changes),
-        lists:foldl(fun(Node, ListOfPercentClaimed) ->
-            ListOfPercentClaimed ++ [{Node, claim_percent(Ring, Node)}]
-                    end, [], Members),
-        lists:foldl(fun(Node, ListOfPercentPending) ->
-            ListOfPercentPending ++ [{Node, future_claim_percentage(Changes, Ring, Node)}]
-                    end, [], Members)
+        [{Node, claim_percent(Ring, Node)} || Node <- Members],
+        [{Node, future_claim_percentage(Changes, Ring, Node)} || Node <- Members]
     ]),
 
 %% ring status

--- a/src/bcounter_mgr.erl
+++ b/src/bcounter_mgr.erl
@@ -196,18 +196,9 @@ do_request(MyDCId, RemoteId, Key, Amount) ->
 pref_list(Obj) ->
     MyDCId = dc_utilities:get_my_dc_id(),
     OtherDCDescriptors = dc_meta_data_utilities:get_dc_descriptors(),
-    OtherDCIds = lists:foldl(fun(#descriptor{dcid=Id}, IdsList) ->
-                                     case Id == MyDCId of
-                                         true -> IdsList;
-                                         false -> [Id | IdsList]
-                                     end
-                             end, [], OtherDCDescriptors),
-    lists:sort(
-      fun({_, A}, {_, B}) -> A =< B end,
-      lists:foldl(fun(Id, Accum) ->
-                          Permissions = ?DATA_TYPE:localPermissions(Id, Obj),
-                          [{Id, Permissions} | Accum]
-                  end, [], OtherDCIds)).
+    OtherDCIds = [ Id || #descriptor{dcid=Id} <- OtherDCDescriptors, Id /= MyDCId ],
+    OtherDCPermissions = [ {Id, ?DATA_TYPE:localPermissions(Id, Obj)} || Id <- OtherDCIds],
+    lists:sort(fun({_, A}, {_, B}) -> A =< B end, OtherDCPermissions).
 
 %% Request response - do nothing.
 request_response(_BinaryRep, _RequestCacheEntry) -> ok.

--- a/src/clocksi_vnode.erl
+++ b/src/clocksi_vnode.erl
@@ -154,12 +154,12 @@ send_min_prepared(Partition) ->
 
 %% @doc Sends a prepare request to a Node involved in a tx identified by TxId
 prepare(ListofNodes, TxId) ->
-    lists:foldl(fun({Node, WriteSet}, _Acc) ->
+    lists:foreach(fun({Node, WriteSet}) ->
         riak_core_vnode_master:command(Node,
             {prepare, TxId, WriteSet},
             {fsm, undefined, self()},
             ?CLOCKSI_MASTER)
-    end, ok, ListofNodes).
+    end, ListofNodes).
 
 
 %% @doc Sends prepare+commit to a single partition
@@ -180,21 +180,21 @@ single_commit_sync([{Node, WriteSet}], TxId) ->
 
 %% @doc Sends a commit request to a Node involved in a tx identified by TxId
 commit(ListofNodes, TxId, CommitTime) ->
-    lists:foldl(fun({Node, WriteSet}, _Acc) ->
+    lists:foreach(fun({Node, WriteSet}) ->
         riak_core_vnode_master:command(Node,
             {commit, TxId, CommitTime, WriteSet},
             {fsm, undefined, self()},
             ?CLOCKSI_MASTER)
-    end, ok, ListofNodes).
+    end, ListofNodes).
 
 %% @doc Sends a commit request to a Node involved in a tx identified by TxId
 abort(ListofNodes, TxId) ->
-    lists:foldl(fun({Node, WriteSet}, _Acc) ->
+    lists:foreach(fun({Node, WriteSet}) ->
         riak_core_vnode_master:command(Node,
             {abort, TxId, WriteSet},
             {fsm, undefined, self()},
             ?CLOCKSI_MASTER)
-    end, ok, ListofNodes).
+    end, ListofNodes).
 
 get_cache_name(Partition, Base) ->
     list_to_atom(atom_to_list(node()) ++ atom_to_list(Base) ++ "-" ++ integer_to_list(Partition)).

--- a/src/clocksi_vnode.erl
+++ b/src/clocksi_vnode.erl
@@ -150,15 +150,7 @@ get_active_txns_internal(TableName) ->
                     [] ->
                         [];
                     [{Key1, List1} | Rest1] ->
-                        lists:foldl(fun({_Key, List}, Acc) ->
-                            case List of
-                                [] ->
-                                    Acc;
-                                _ ->
-                                    List ++ Acc
-                            end
-                        end,
-                            [], [{Key1, List1} | Rest1])
+                        lists:flatmap(fun({_, _List}) -> _List end, [{Key1, List1} | Rest1])
                 end,
     {ok, ActiveTxs}.
 

--- a/src/clocksi_vnode.erl
+++ b/src/clocksi_vnode.erl
@@ -146,12 +146,7 @@ get_active_txns(Partition, TableName) ->
     end.
 
 get_active_txns_internal(TableName) ->
-    ActiveTxs = case ets:tab2list(TableName) of
-                    [] ->
-                        [];
-                    [{Key1, List1} | Rest1] ->
-                        lists:flatmap(fun({_, _List}) -> _List end, [{Key1, List1} | Rest1])
-                end,
+    ActiveTxs = lists:flatmap(fun({_, List}) -> List end, ets:tab2list(TableName)),
     {ok, ActiveTxs}.
 
 send_min_prepared(Partition) ->

--- a/src/materializer_vnode.erl
+++ b/src/materializer_vnode.erl
@@ -527,11 +527,8 @@ snapshot_insert_gc(Key, SnapshotDict, ShouldGc, #state{snapshot_cache = Snapshot
         true ->
             %% snapshots are no longer totally ordered
             PrunedSnapshots = vector_orddict:sublist(SnapshotDict, 1, ?SNAPSHOT_MIN),
-            FirstOp = vector_orddict:last(PrunedSnapshots),
-            {CT, _S} = FirstOp,
-            CommitTime = lists:foldl(fun({CT1, _ST}, Acc) ->
-                                         vectorclock:min([CT1, Acc])
-                                     end, CT, vector_orddict:to_list(PrunedSnapshots)),
+            CommitTimeList = [ CT || {CT, _S} <- vector_orddict:to_list(PrunedSnapshots)],
+            CommitTime = vectorclock:min(CommitTimeList),
             {Key, Length, OpId, ListLen, OpsDict} =
                 case ets:lookup(OpsCache, Key) of
                     [] ->

--- a/test/utils/test_utils.erl
+++ b/test/utils/test_utils.erl
@@ -329,10 +329,10 @@ set_up_clusters_common(Config) ->
             connect ->
                 ct:pal("~p of ~p subscribing to other external DCs", [MainNode, unpack(CurrentCluster)]),
 
-                Descriptors = lists:foldl(fun([{_Status, FirstNode} | _], Descriptors) ->
+                Descriptors = lists:map(fun([{_Status, FirstNode} | _]) ->
                     {ok, Descriptor} = rpc:call(FirstNode, antidote_dc_manager, get_connection_descriptor, []),
-                    Descriptors ++ [Descriptor]
-                                          end, [], Clusters),
+                    Descriptor
+                                        end, Clusters),
 
                 %% subscribe to descriptors of other dcs
                 ok = rpc:call(MainNode, antidote_dc_manager, subscribe_updates_from, [Descriptors])


### PR DESCRIPTION
Reviewing calls to lists:foldl and optimizing them when possible (e.g. by replacing foldl with a list comprehension or a more efficient list function)