### PR TITLE
Improve Interdc communication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ script:
   - rebar3 as test coveralls send
   - make dialyzer
   - make lint
+after_failure:
+  - find logs -name '*.log' -exec echo -e "\e[41m#####################################" \; -exec echo {} \; -exec echo -e "#####################################\e[0m" \; -exec cat {} \;
 notifications:
   email: bieniusa@cs.uni-kl.de
 sudo: required

--- a/include/antidote.hrl
+++ b/include/antidote.hrl
@@ -64,6 +64,10 @@
 -define(SAFE_TIME, true).
 %% Version of log records being used
 -define(LOG_RECORD_VERSION, 0).
+%% Max number of entries per log get_entries request.
+-define(LOG_REQUEST_MAX_ENTRIES, 1000).
+%% Log request timeout in milliseconds.
+-define(LOG_REQUEST_TIMEOUT, 60000).
 %% Bounded counter manager parameters.
 %% Period during which transfer requests from the same DC to the same key are ignored.
 -define(GRACE_PERIOD, 1000000). % in Microseconds

--- a/include/inter_dc_repl.hrl
+++ b/include/inter_dc_repl.hrl
@@ -64,6 +64,7 @@
   pdcid :: pdcid(),
   last_observed_opid :: non_neg_integer() | init,
   queue :: queue:queue(),
-  logging_enabled :: boolean()
+  logging_enabled :: boolean(),
+  log_reader_timeout :: integer()
 }).
 -type inter_dc_sub_buf() :: #inter_dc_sub_buf{}.

--- a/rebar.config
+++ b/rebar.config
@@ -78,13 +78,14 @@
     {extended_start_script, true}
 ]}.
 
-{profiles,[
-  {lint, [
-    {plugins, [{rebar3_lint, {git, "https://github.com/project-fifo/rebar3_lint.git", {tag, "v0.1.10"}}}]}
-  ]},
-  {test, [
-    {erl_opts, [warnings_as_errors, debug_info, no_inline_list_funcs]},
-    {plugins, [{coveralls, {git, "https://github.com/markusn/coveralls-erl", {branch, "master"}}}]}]}
+{profiles, [
+    {lint, [
+        {plugins, [{rebar3_lint, {git, "https://github.com/project-fifo/rebar3_lint.git", {tag, "v0.1.10"}}}]}
+    ]},
+    {test, [
+        {erl_opts, [warnings_as_errors, debug_info, no_inline_list_funcs]},
+        {plugins, [{coveralls, {git, "https://github.com/markusn/coveralls-erl", {branch, "master"}}}]},
+        {deps, [meck]}]}
 ]}.
 
 % configuration of style rules

--- a/src/inter_dc_query_response.erl
+++ b/src/inter_dc_query_response.erl
@@ -109,6 +109,7 @@ get_entries_internal(Partition, From, To) ->
     Logs = log_read_range(Partition, Node, From, To),
     Asm = log_txn_assembler:new_state(),
     {OpLists, _} = log_txn_assembler:process_all(Logs, Asm),
+    %% Transforming operation lists to transactions and set PrevLogOpId
     ProcessedOps = lists:map(fun(Ops) -> [FirstOp|_] = Ops, {Ops, #op_number{local = FirstOp#log_record.op_number#op_number.local - 1}} end, OpLists),
     Txns = lists:map(fun({TxnOps, PrevLogOpId}) -> inter_dc_txn:from_ops(TxnOps, Partition, PrevLogOpId) end, ProcessedOps),
     %% This is done in order to ensure that we only send the transactions we committed.

--- a/src/inter_dc_query_response.erl
+++ b/src/inter_dc_query_response.erl
@@ -75,7 +75,8 @@ init([Num]) ->
 
 handle_cast({get_entries, BinaryQuery, QueryState}, State) ->
     {read_log, Partition, From, To} = binary_to_term(BinaryQuery),
-    Entries = get_entries_internal(Partition, From, To),
+    LimitedTo = erlang:min(To, From + ?LOG_REQUEST_MAX_ENTRIES), %% Limit number of returned entries
+    Entries = get_entries_internal(Partition, From, LimitedTo),
     BinaryResp = term_to_binary({{dc_utilities:get_my_dc_id(), Partition}, Entries}),
     BinaryPartition = inter_dc_txn:partition_to_bin(Partition),
     FullResponse = <<BinaryPartition/binary, BinaryResp/binary>>,
@@ -100,34 +101,26 @@ handle_info(_Info, State) ->
 
 -spec get_entries_internal(partition_id(), log_opid(), log_opid()) -> [interdc_txn()].
 get_entries_internal(Partition, From, To) ->
-  Node = case lists:member(Partition, dc_utilities:get_my_partitions()) of
-             true -> node();
-             false ->
-                 log_utilities:get_my_node(Partition)
-         end,
-  Logs = log_read_range(Partition, Node, From, To),
-  Asm = log_txn_assembler:new_state(),
-  {OpLists, _} = log_txn_assembler:process_all(Logs, Asm),
-  Txns = lists:map(fun(TxnOps) -> inter_dc_txn:from_ops(TxnOps, Partition, none) end, OpLists),
-  %% This is done in order to ensure that we only send the transactions we committed.
-  %% We can remove this once the read_log_range is reimplemented.
-  lists:filter(fun inter_dc_txn:is_local/1, Txns).
+    Node = case lists:member(Partition, dc_utilities:get_my_partitions()) of
+               true -> node();
+               false ->
+                   log_utilities:get_my_node(Partition)
+           end,
+    Logs = log_read_range(Partition, Node, From, To),
+    Asm = log_txn_assembler:new_state(),
+    {OpLists, _} = log_txn_assembler:process_all(Logs, Asm),
+    ProcessedOps = lists:map(fun(Ops) -> [FirstOp|_] = Ops, {Ops, #op_number{local = FirstOp#log_record.op_number#op_number.local - 1}} end, OpLists),
+    Txns = lists:map(fun({TxnOps, PrevLogOpId}) -> inter_dc_txn:from_ops(TxnOps, Partition, PrevLogOpId) end, ProcessedOps),
+    %% This is done in order to ensure that we only send the transactions we committed.
+    %% We can remove this once the read_log_range is reimplemented.
+    lists:filter(fun inter_dc_txn:is_local/1, Txns).
 
 %% TODO: re-implement this method efficiently once the log provides efficient access by partition and DC (Santiago, here!)
 %% TODO: also fix the method to provide complete snapshots if the log was trimmed
 -spec log_read_range(partition_id(), node(), log_opid(), log_opid()) -> [log_record()].
 log_read_range(Partition, Node, From, To) ->
-  {ok, RawOpList} = logging_vnode:read({Partition, Node}, [Partition]),
-  OpList = lists:map(fun({_Partition, Op}) -> Op end, RawOpList),
-  filter_operations(OpList, From, To).
-
--spec filter_operations([log_record()], log_opid(), log_opid()) -> [log_record()].
-filter_operations(Ops, Min, Max) ->
-  F = fun(Op) ->
-    Num = Op#log_record.op_number#op_number.local,
-    (Num >= Min) and (Max >= Num)
-  end,
-  lists:filter(F, Ops).
+  {ok, RawOpList} = logging_vnode:read_from_to({Partition, Node}, [Partition], From, To),
+  lists:map(fun({_Partition, Op}) -> Op end, RawOpList).
 
 %% @private
 terminate(_Reason, _State) ->

--- a/src/inter_dc_sub_buf.erl
+++ b/src/inter_dc_sub_buf.erl
@@ -178,7 +178,7 @@ process_init() ->
     Txn = make_txn(0),
     NewState = process({txn, Txn}, State),
     ?assertEqual(normal, NewState#inter_dc_sub_buf.state_name),
-    check_meck_calls(1,1,1,0).
+    check_meck_calls(1, 1, 1, 0).
 
 process_old() ->
     meck_reset(),
@@ -186,7 +186,7 @@ process_old() ->
     Txn = make_txn(-1),
     NewState = process({txn, Txn}, State#inter_dc_sub_buf{state_name = normal, last_observed_opid=0}),
     ?assertEqual(normal, NewState#inter_dc_sub_buf.state_name),
-    check_meck_calls(0,0,0,0).
+    check_meck_calls(0, 0, 0, 0).
 
 process_missing_txn() ->
     meck_reset(),
@@ -195,7 +195,7 @@ process_missing_txn() ->
     NewState = process({txn, Txn}, State#inter_dc_sub_buf{state_name = normal, last_observed_opid=0}),
     ?assertEqual(1, meck:num_calls(inter_dc_query, perform_request, '_')),
     ?assertEqual(buffering, NewState#inter_dc_sub_buf.state_name),
-    check_meck_calls(0,0,0,1).
+    check_meck_calls(0, 0, 0, 1).
 
 process_buffering() ->
     meck_reset(),
@@ -203,10 +203,10 @@ process_buffering() ->
     Txn = make_txn(1),
     NewState = process({txn, Txn}, State#inter_dc_sub_buf{state_name = buffering, log_reader_timeout = erlang:system_time(millisecond) + 3000, last_observed_opid=0}),
     ?assertEqual(buffering, NewState#inter_dc_sub_buf.state_name),
-    check_meck_calls(0,0,0,0),
+    check_meck_calls(0, 0, 0, 0),
     NewState2 = process({txn, Txn}, State#inter_dc_sub_buf{state_name = buffering, log_reader_timeout = erlang:system_time(millisecond) - 1000, last_observed_opid=0}),
     ?assertEqual(buffering, NewState2#inter_dc_sub_buf.state_name),
-    check_meck_calls(0,0,0,1).
+    check_meck_calls(0, 0, 0, 1).
 
 process_resp() ->
     meck_reset(),
@@ -219,7 +219,7 @@ process_resp() ->
     NormalState = process({log_reader_resp, [Txn2]}, BufState),
     ?assertEqual(normal, NormalState#inter_dc_sub_buf.state_name),
     ?assertEqual(0, queue:len(NormalState#inter_dc_sub_buf.queue)),
-    check_meck_calls(0,0,2,1).
+    check_meck_calls(0, 0, 2, 1).
 
 make_txn(Last) ->
     #interdc_txn{

--- a/test/multidc/multiple_dcs_node_failure_SUITE.erl
+++ b/test/multidc/multiple_dcs_node_failure_SUITE.erl
@@ -45,7 +45,8 @@
 -export([
          multiple_cluster_failure_test/1,
          cluster_failure_test/1,
-         update_during_cluster_failure_test/1]).
+         update_during_cluster_failure_test/1,
+         update_during_cluster_failure_test2/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -82,7 +83,8 @@ end_per_testcase(Name, _) ->
 all() -> [
     multiple_cluster_failure_test,
     cluster_failure_test,
-    update_during_cluster_failure_test
+    update_during_cluster_failure_test,
+    update_during_cluster_failure_test2
 ].
 
 %% In this test there are 3 DCs each with 1 node
@@ -235,6 +237,59 @@ update_during_cluster_failure_test(Config) ->
             pass
     end.
 
+% Similar to the previous test, but uses more updates to better test log recovery
+update_during_cluster_failure_test2(Config) ->
+    Bucket = ?BUCKET,
+    Clusters = proplists:get_value(clusters, Config),
+    [Node1, Node2, Node3 | _Nodes] =  [ hd(Cluster)|| Cluster <- Clusters ],
+    Key = update_during_cluster_failure_test,
+    Type = antidote_crdt_counter_pn,
+
+    case rpc:call(Node1, application, get_env, [antidote, enable_logging]) of
+        {ok, false} ->
+            ct:pal("Logging is disabled!"),
+            pass;
+        _ ->
+            {ok, CommitTime} = update_counter_n(Node1, Key, 1000, ignore, static, Bucket),
+            ct:log("Done append in Node1"),
+
+            %% Kill a node
+            ct:log("Killing node ~w", [Node1]),
+            [Node1] = test_utils:brutal_kill_nodes([Node1]),
+
+            %check_read_key(Node2, Key, Type, 1000, CommitTime, static, Bucket),
+            %check_read_key(Node3, Key, Type, 1000, CommitTime, static, Bucket),
+
+            %% Be sure the other DC works while the node is down
+            {ok, CommitTime3a} = update_counters(Node2, [Key], [1], ignore, static, Bucket),
+            {ok, CommitTime3b} = update_counters(Node3, [Key], [1], ignore, static, Bucket),
+
+            %% Start the node back up and be sure everything works
+            ct:log("Restarting node ~w", [Node1]),
+            [Node1] = test_utils:restart_nodes([Node1], Config),
+
+            %% Take the max of the commit times to be sure
+            %% to read all updates
+            Time = vectorclock:max([CommitTime, CommitTime3a, CommitTime3b]),
+
+            check_read_key(Node1, Key, Type, 1002, Time, static, Bucket),
+            ct:log("Done Read in Node1"),
+
+            check_read_key(Node3, Key, Type, 1002, Time, static, Bucket),
+            ct:log("Done Read in Node3"),
+            check_read_key(Node2, Key, Type, 1002, Time, static, Bucket),
+            ct:log("Done first round of read, I am gonna append"),
+
+            {ok, CommitTime1} = update_counters(Node1, [Key], [1], Time, static, Bucket),
+            {ok, CommitTime2} = update_counters(Node2, [Key], [1], CommitTime1, static, Bucket),
+            {ok, CommitTime3} = update_counters(Node3, [Key], [1], CommitTime2, static, Bucket),
+
+            SnapshotTime = CommitTime3,
+            check_read_key(Node1, Key, Type, 1005, SnapshotTime, static, Bucket),
+            check_read_key(Node2, Key, Type, 1005, SnapshotTime, static, Bucket),
+            check_read_key(Node3, Key, Type, 1005, SnapshotTime, static, Bucket),
+            pass
+    end.
 
 
 check_read_key(Node, Key, Type, Expected, Clock, TxId, Bucket) ->
@@ -267,3 +322,9 @@ update_counters(Node, Keys, IncValues, Clock, TxId, Bucket) ->
             ok = rpc:call(Node, cure, update_objects, [Updates, TxId], ?RPC_TIMEOUT),
             ok
     end.
+
+update_counter_n(_Node, _Key, 0, Clock, _TxId, _Bucket) -> {ok, Clock};
+update_counter_n(Node, Key, N, Clock, TxId, Bucket) ->
+    {ok, Clock2} = update_counters(Node, [Key], [1], Clock, TxId, Bucket),
+    update_counter_n(Node, Key, N - 1, Clock2, TxId, Bucket).
+

--- a/test/multidc/multiple_dcs_node_failure_SUITE.erl
+++ b/test/multidc/multiple_dcs_node_failure_SUITE.erl
@@ -35,6 +35,7 @@
 
 %% common_test callbacks
 -export([
+         suite/0,
          init_per_suite/1,
          end_per_suite/1,
          init_per_testcase/2,
@@ -50,6 +51,8 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(BUCKET, test_utils:bucket(multiple_dcs_node_failure_bucket)).
+
+suite() -> [{timetrap, {seconds, 120}}].
 
 init_per_suite(InitialConfig) ->
     Config = test_utils:init_multi_dc(?MODULE, InitialConfig),


### PR DESCRIPTION
This PR limits the entries per request read from log for recovering missing transactions. Entries from log can be read using continuations. Reducing load and prevent possible crashes.
Timeout added for request that read from log.