### PR TITLE
Fixed dialyzer issues for OTP 23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: erlang
 otp_release:
   - 21.3
   - 22.3
-    #  - 23.0
+  - 23.0
 install:
   - make
   - ./rebar3 update

--- a/src/clocksi_interactive_coord.erl
+++ b/src/clocksi_interactive_coord.erl
@@ -259,10 +259,7 @@ wait_for_start_transaction({call, Sender}, {start_tx, ClientClock, Properties}, 
 %%      operation, wait for it to finish (synchronous) and go to the prepareOP
 %%       to execute the next operation.
 %% internal state timeout
--spec execute_op(state_timeout, timeout, state()) -> gen_statem:event_handler_result(state());
-    ({call, pid()}, undefined | list() | {update_objects, list()} | {update, list()}, state()) -> gen_statem:event_handler_result(state()).
-execute_op(state_timeout, timeout, State = #state{operations = Operations, from = From}) ->
-    execute_op({call, From}, Operations, State);
+-spec execute_op({call, gen_statem:from()}, {update | update_objects | read_objects | read | abort | prepare, list()}, state()) -> gen_statem:event_handler_result(state()).
 
 %% update kept for backwards compatibility with tests.
 execute_op({call, Sender}, {update, Args}, State) ->
@@ -547,7 +544,7 @@ create_transaction_record(ClientClock, _IsStatic, Properties) ->
 
 
 %% @doc Execute the commit protocol
--spec execute_command(atom(), term(), pid(), state()) -> gen_statem:event_handler_result(state()).
+-spec execute_command(atom(), term(), gen_statem:from(), state()) -> gen_statem:event_handler_result(state()).
 execute_command(prepare, Protocol, Sender, State0) ->
     State = State0#state{from=Sender, commit_protocol=Protocol},
     prepare(State);
@@ -637,7 +634,7 @@ reply_to_client(State = #state{
         undefined ->
             ok;
 
-        Node ->
+        {_Pid, _Tag} ->
 
             Reply = case TxState of
                         committed_read_only ->
@@ -674,12 +671,7 @@ reply_to_client(State = #state{
 %%                        Reason ->
 %%                            {TxId, Reason}
                     end,
-            case is_pid(Node) of
-                false ->
-                    gen_statem:reply(Node, Reply);
-                true ->
-                    From ! Reply
-            end
+            gen_statem:reply(From, Reply)
     end,
 
     % transaction is finished, decrement count
@@ -767,10 +759,7 @@ perform_read({Key, Type}, UpdatedPartitions, Transaction, Sender) ->
             Snapshot;
 
         {error, Reason} ->
-            case Sender of
-                undefined -> ok;
-                _ -> gen_statem:reply(Sender, {error, Reason})
-            end,
+            gen_statem:reply(Sender, {error, Reason}),
             {error, Reason}
     end.
 


### PR DESCRIPTION
The first execute_op must be deleted because it will never be called (there is no defined timeout so it can never happen)
The From/Sender is defined as either undefined or gen_statem:from() (which is {pid(), term()}) so it can never be just a pid