### PR TITLE
Fixed a bug in the function get_dc_descriptors()

### DIFF
--- a/src/dc_meta_data_utilities.erl
+++ b/src/dc_meta_data_utilities.erl
@@ -125,7 +125,8 @@ get_dc_descriptors() ->
         error ->
             ?LOG_DEBUG("Could not read shared meta data for external_descriptors"),
             %% return self descriptor only
-            [inter_dc_manager:get_descriptor()]
+            {ok, Descriptor} = inter_dc_manager:get_descriptor(),
+            [Descriptor]
     end.
 
 


### PR DESCRIPTION
It was returning [{ok, descriptor()}] when there was no metadata available
The spec says it should return [descriptor()] which is now fixed with this commit