### PR TITLE
Tests for join after replicate

### DIFF
--- a/src/inter_dc_pub.erl
+++ b/src/inter_dc_pub.erl
@@ -100,7 +100,7 @@ handle_cast(_Request, State) ->
 %% bind shutdown
 handle_info({'EXIT', Pid, Reason}, State) ->
     ?LOG_CRITICAL("Bind router socket ~p shutdown: ~p", [Pid, Reason]),
-    {stop, {bind_socket_shutdown, Reason}, State};
+    {noreply, State};
 handle_info(_Info, State) ->
     {noreply, State}.
 

--- a/test/multidc/inter_dc_zmq_SUITE.erl
+++ b/test/multidc/inter_dc_zmq_SUITE.erl
@@ -151,7 +151,7 @@ pub_alone(_Config) ->
         chumak:subscribe(SubSocket, Topic),
         {ok, _SocketPid} = chumak:connect(SubSocket, tcp, "localhost", 15554),
         %% wait until socket connected properly
-        timer:sleep(20),
+        timer:sleep(100),
         Self ! step,
         {ok, Message} = chumak:recv(SubSocket),
         ok = inter_dc_utils:close_socket(SubSocket),

--- a/test/multidc/multiple_dcs_SUITE.erl
+++ b/test/multidc/multiple_dcs_SUITE.erl
@@ -41,7 +41,8 @@
          simple_replication_test/1,
          failure_test/1,
          blocking_test/1,
-         parallel_writes_test/1]).
+         parallel_writes_test/1
+]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").

--- a/test/multidc/multiple_dcs_repl_SUITE.erl
+++ b/test/multidc/multiple_dcs_repl_SUITE.erl
@@ -1,0 +1,98 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright <2013-2018> <
+%%  Technische Universität Kaiserslautern, Germany
+%%  Université Pierre et Marie Curie / Sorbonne-Université, France
+%%  Universidade NOVA de Lisboa, Portugal
+%%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
+%% >
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either expressed or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% List of the contributors to the development of Antidote: see AUTHORS file.
+%% Description and complete License: see LICENSE file.
+%% -------------------------------------------------------------------
+
+-module(multiple_dcs_repl_SUITE).
+
+%% common_test callbacks
+-export([
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_testcase/2,
+    end_per_testcase/2,
+    all/0]).
+
+%% tests
+-export([
+    join_to_replicate/1
+]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(ADDRESS, "localhost").
+-define(PORT, 10017).
+-define(BUCKET_BIN, term_to_binary(test_utils:bucket(multiple_dcs_repl_SUITE))).
+
+
+init_per_suite(_Config) ->
+    [].
+
+
+end_per_suite(Config) ->
+    Config.
+
+
+init_per_testcase(_Case, Config) ->
+    Config.
+
+
+end_per_testcase(Name, _) ->
+    ct:print("[ OK ] ~p", [Name]),
+    ok.
+
+
+all() -> [
+    join_to_replicate
+].
+
+join_to_replicate(Config) ->
+    NodeNames = [dcdev1, dcdev2],
+    Nodes = test_utils:pmap(fun(Node) -> test_utils:start_node(Node, Config) end, NodeNames),
+    [Node, ReplNode] = test_utils:unpack(Nodes),
+
+    Bucket = ?BUCKET_BIN,
+
+    % write counter on dcdv1:
+    Times = 300,
+    ct:log("Starting ~p write operations and 1 read", [Times]),
+    %% concurrent requests will throw {error, aborted}
+%%    test_utils:pmap(fun(_) -> antidote_utils:increment_pn_counter(Node, append_key1, Bucket) end, lists:seq(0, Times)),
+    [ antidote_utils:increment_pn_counter(Node, append_key1, Bucket) || _ <- lists:seq(1, Times - 1)],
+    Clock = antidote_utils:increment_pn_counter(Node, append_key1, Bucket),
+    {Val1, _} = antidote_utils:read_pn_counter(Node, append_key1, Bucket, Clock),
+    Val1 = Times,
+
+    {ok, DescriptorMain} = rpc:call(Node, antidote_dc_manager, get_connection_descriptor, []),
+    {ok, DescriptorRepl} = rpc:call(Node, antidote_dc_manager, get_connection_descriptor, []),
+
+    %% subscribe to descriptors of other dcs
+    ok = rpc:call(ReplNode, antidote_dc_manager, subscribe_updates_from, [[DescriptorMain]]),
+    ok = rpc:call(Node, antidote_dc_manager, subscribe_updates_from, [[DescriptorRepl]]),
+
+    %% read on repl node
+    {Val1, _} = antidote_utils:read_pn_counter(ReplNode, append_key1, Bucket, Clock).

--- a/test/utils/antidote_utils.erl
+++ b/test/utils/antidote_utils.erl
@@ -38,6 +38,7 @@
     increment_pn_counter/3,
 
     read_pn_counter/3,
+    read_pn_counter/4,
     read_b_counter/3,
     read_b_counter_commit/4,
 
@@ -62,13 +63,18 @@
 increment_pn_counter(Node, Key, Bucket) ->
     Obj = {Key, ?TYPE_PNC, Bucket},
     WriteResult = rpc:call(Node, antidote, update_objects, [ignore, [], [{Obj, increment, 1}]]),
-    ?assertMatch({ok, _}, WriteResult),
-    ok.
+    {ok, Vectorclock} = WriteResult,
+    Vectorclock.
 
 
 read_pn_counter(Node, Key, Bucket) ->
     Obj = {Key, ?TYPE_PNC, Bucket},
     {ok, [Value], CommitTime} = rpc:call(Node, antidote, read_objects, [ignore, [], [Obj]]),
+    {Value, CommitTime}.
+
+read_pn_counter(Node, Key, Bucket, Clock) ->
+    Obj = {Key, ?TYPE_PNC, Bucket},
+    {ok, [Value], CommitTime} = rpc:call(Node, antidote, read_objects, [Clock, [], [Obj]]),
     {Value, CommitTime}.
 
 

--- a/test/utils/test_utils.erl
+++ b/test/utils/test_utils.erl
@@ -281,7 +281,9 @@ web_ports(clusterdev2) -> 10125;
 web_ports(clusterdev3) -> 10135;
 web_ports(clusterdev4) -> 10145;
 web_ports(clusterdev5) -> 10155;
-web_ports(clusterdev6) -> 10165.
+web_ports(clusterdev6) -> 10165;
+web_ports(dcdev1) -> 10215;
+web_ports(dcdev2) -> 10225.
 
 
 %% Build clusters for all test suites.


### PR DESCRIPTION
Added system test case for joining a cluster to replicate to one more empty DC. Tests that requests for missing log entries are requested properly by `inter_dc_query_dealer`.
Added more time for socket to open in `inter_dc_zmq_SUITE`.