### PR TITLE
Changed from plugins to project_plugins

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -65,8 +65,7 @@
 
 %% Do not update this dependency without testing lint
 %% Something is broken in the rebar3 build process that causes this plugin to call modules that are not its actual dependencies
-%% This should actually be executed in a lint profile
-{plugins, [{rebar3_lint, {git, "https://github.com/project-fifo/rebar3_lint.git", {tag, "v0.1.10"}}}]}.
+{project_plugins, [{rebar3_lint, "0.1.10"}]}.
 
 {profiles, [
     {test, [


### PR DESCRIPTION
Reason:
If antidote is used as dependency the rebar3_lint plugin is not required and should not be compiled
See:
https://rebar3.org/docs/plugins/#project-plugins-and-overriding-commands