### PR TITLE
Use the antidote_crdt module instead of the CRDT type

### DIFF
--- a/src/clocksi_downstream.erl
+++ b/src/clocksi_downstream.erl
@@ -40,7 +40,7 @@
     {ok, effect()} | {error, atom()}.
 generate_downstream_op(Transaction, IndexNode, Key, Type, Update, WriteSet) ->
     %% TODO: Check if read can be omitted for some types as registers
-    NeedState = Type:require_state_downstream(Update),
+    NeedState = antidote_crdt:require_state_downstream(Type, Update),
     Result =
         %% If state is needed to generate downstream, read it from the partition.
         case NeedState of
@@ -63,6 +63,6 @@ generate_downstream_op(Transaction, IndexNode, Key, Type, Update, WriteSet) ->
                     %% bcounter data-type.
                     bcounter_mgr:generate_downstream(Key, Update, Snapshot);
                 _ ->
-                    Type:downstream(Update, Snapshot)
+                    antidote_crdt:downstream(Type, Update, Snapshot)
             end
     end.

--- a/src/cure.erl
+++ b/src/cure.erl
@@ -187,7 +187,7 @@ transform_reads(States, StateOrValue, Objects) ->
     case StateOrValue of
             object_state -> States;
             object_value -> lists:map(fun({State, {_Key, Type, _Bucket}}) ->
-                                          Type:value(State) end,
+                                          antidote_crdt:value(Type, State) end,
                                       lists:zip(States, Objects))
     end.
 

--- a/src/materializer.erl
+++ b/src/materializer.erl
@@ -46,14 +46,14 @@
 %% @doc Creates an empty CRDT
 -spec create_snapshot(type()) -> snapshot().
 create_snapshot(Type) ->
-    Type:new().
+    antidote_crdt:new(Type).
 
 %% @doc Applies an downstream effect to a snapshot of a crdt.
 %%      This function yields an error if the crdt does not have a corresponding update operation.
 -spec update_snapshot(type(), snapshot(), effect()) -> {ok, snapshot()} | {error, reason()}.
 update_snapshot(Type, Snapshot, Op) ->
     try
-        Type:update(Op, Snapshot)
+        antidote_crdt:update(Type, Op, Snapshot)
     catch
         _:_ ->
             {error, {unexpected_operation, Op, Type}}
@@ -90,7 +90,7 @@ check_operation(Op) ->
     case Op of
         {update, {_, Type, Update}} ->
             antidote_crdt:is_type(Type) andalso
-                Type:is_operation(Update);
+                antidote_crdt:is_operation(Type, Update);
         {read, {_, Type}} ->
             antidote_crdt:is_type(Type);
         _ ->
@@ -143,7 +143,7 @@ materializer_counter_emptylog_test() ->
 
 %% Testing non-existing crdt
 materializer_error_nocreate_test() ->
-    ?assertException(error, undef, create_snapshot(bla)).
+    ?assertException(error, {badmatch, false}, create_snapshot(bla)).
 
 %% Testing crdt with invalid update operation
 materializer_error_invalidupdate_test() ->


### PR DESCRIPTION
With the introduction of the new CRDT type aliases in AntidoteDB/antidote_crdt#40, it is now possible that some CRDTs do not have an actual implementation server side, they are simply mapped to an implementation of another CRDT.

Using `Type:function(...)` instead of `antidote_crdt:function(Type, ...)` results in an undefined error when `Type` is an alias. This PR fixes that.