### PR TITLE
Add a read or validate API

### DIFF
--- a/include/antidote.hrl
+++ b/include/antidote.hrl
@@ -231,6 +231,12 @@
 -type bucket() :: term().
 -type snapshot() :: term().
 -type object_token() :: binary().
+
+%% A special token for the validate_or_read API that is always considered
+%% as invalid.
+%%
+%% It is useful for when no sensible token can be returned or when the caller
+%% explicitly wants the value.
 -define(INVALID_OBJECT_TOKEN, <<>>).
 
 -type tx() :: #transaction{}.

--- a/include/antidote.hrl
+++ b/include/antidote.hrl
@@ -230,6 +230,8 @@
 -type log_id() :: [partition_id()].
 -type bucket() :: term().
 -type snapshot() :: term().
+-type object_token() :: binary().
+-define(INVALID_OBJECT_TOKEN, <<>>).
 
 -type tx() :: #transaction{}.
 -type cache_id() :: ets:tab().

--- a/src/antidote.erl
+++ b/src/antidote.erl
@@ -37,6 +37,7 @@
           start_transaction/2,
           read_objects/2,
           read_objects/3,
+          validate_or_read_objects/3,
           update_objects/2,
           update_objects/3,
           abort_transaction/1,
@@ -148,6 +149,13 @@ read_objects(Objects, TxId) ->
                   -> {ok, list(), vectorclock()} | {error, reason()}.
 read_objects(Clock, Properties, Objects) ->
     cure:read_objects(Clock, Properties, Objects).
+
+-spec validate_or_read_objects(Objects::[bound_object()],
+                               Tokens::[object_token()],
+                               TxId::txid())
+    -> {ok, {[term()], [object_token()]}} | {error, reason()}.
+validate_or_read_objects(Objects, Tokens, TxId) ->
+    cure:validate_or_read_objects(Objects, Tokens, TxId).
 
 %% Returns a list containing tuples of object state and commit time for each
 %% of those objects

--- a/src/clocksi_vnode.erl
+++ b/src/clocksi_vnode.erl
@@ -120,9 +120,6 @@ validate_or_read_data_item(Node, TxId, Key, Type, Token, Updates) ->
 
             {ok, {invalid, Snapshot2, ?INVALID_OBJECT_TOKEN}};
         {ok, valid} ->
-            % When valid, there shouldn't be any update to apply here and the
-            % provided Token is necessarily invalid.
-            ?INVALID_OBJECT_TOKEN = Token,
             {ok, valid};
         {error, Reason} ->
             {error, Reason}

--- a/src/materializer_vnode.erl
+++ b/src/materializer_vnode.erl
@@ -444,7 +444,7 @@ fetch_updates_from_cache(OpsCache, Key) ->
     end.
 
 -spec materialize_snapshot(txid() | ignore, key(), type(), snapshot_time(), boolean(), state(), snapshot_get_response())
-    -> {ok, snapshot_time()} | {error, reason()}.
+    -> {ok, snapshot()} | {error, reason()}.
 
 materialize_snapshot(_TxId, _Key, _Type, _SnapshotTime, _ShouldGC, _State, #snapshot_get_response{
             number_of_ops=0,

--- a/test/singledc/antidote_SUITE.erl
+++ b/test/singledc/antidote_SUITE.erl
@@ -337,9 +337,7 @@ interactive_txn_validate_or_read_multiple(Config) ->
     % token.
     {ok, Res4} = rpc:call(Node, antidote, validate_or_read_objects,
                           [Objects, [TokenObjectA1, TokenObjectB1], TxId1]),
-    ?assertEqual(
-        [{invalid, 1, <<>>},
-         {invalid, 0, <<>>}], Res4),
+    ?assertMatch([{invalid, 1, <<>>}, _], Res4),
 
     % On a new transaction token for B is still valid.
     {ok, _ClockTxId1} = rpc:call(Node, antidote, commit_transaction, [TxId1]),


### PR DESCRIPTION
This is the first steps for a read or validate API. I plan to update protobuf files when we will have settled on this.

The API takes a arbitrary token as an input, if the token is valid
the client can use the cached value, otherwise the new value is returned
alongside a token for the next call.

* A token is the commit time of a snapshot, if commit time is different
  a new value is returned. An empty token is a niche value that is
  always invalid.

* When the commit time for a snapshot is unknown, the token is considered
  invalid.

* The materializer has been modified a bit to return the commit time alongside
  the snapshot.

* The materializer is the one who does the check to avoid unnecessary data
  round-trips.

* Transactions with local updates always invalidate the token if updates
  concerns the same partition. This use case is considered rare so no
  optimization have been tried on this.

I was not 100% sure if what I did is fully correct, basics test are working and previous tests still pass, happy to hear feedback on this !