### PR TITLE
Fixes timeouts encountered in #459

### DIFF
--- a/src/inter_dc_query_router.erl
+++ b/src/inter_dc_query_router.erl
@@ -323,8 +323,8 @@ meck_test_() -> {
     fun test_init/0,
     fun test_cleanup/1,
     [
-        fun simple/0,
-        fun request_log_entries/0
+        {timeout, 15, fun simple/0},
+        {timeout, 15, fun request_log_entries/0}
 %%        fun request_log_entries_delay/0
     ]}.
 

--- a/test/multidc/multiple_dcs_node_failure_SUITE.erl
+++ b/test/multidc/multiple_dcs_node_failure_SUITE.erl
@@ -241,7 +241,7 @@ update_during_cluster_failure_test(Config) ->
 
 % Similar to the previous test, but uses more updates to better test log recovery
 update_during_cluster_failure_test2(Config) ->
-    ct:timetrap({seconds,240}),
+    ct:timetrap({seconds, 240}),
     Bucket = ?BUCKET,
     Clusters = proplists:get_value(clusters, Config),
     [Node1, Node2, Node3 | _Nodes] =  [ hd(Cluster)|| Cluster <- Clusters ],

--- a/test/multidc/multiple_dcs_node_failure_SUITE.erl
+++ b/test/multidc/multiple_dcs_node_failure_SUITE.erl
@@ -69,7 +69,6 @@ init_per_suite(InitialConfig) ->
 
     %Check that indeed clocksi is running
     {ok, clocksi} = rpc:call(hd(hd(Clusters)), application, get_env, [antidote, txn_prot]),
-
     Config.
 
 end_per_suite(Config) ->
@@ -106,7 +105,7 @@ cluster_failure_test(Config) ->
         {ok, false} ->
             ct:pal("Logging is disabled!"),
             pass;
-        _ ->
+        {ok, true} ->
             update_counters(Node1, [Key], [1], ignore, static, Bucket),
             update_counters(Node1, [Key], [1], ignore, static, Bucket),
             {ok, CommitTime} = update_counters(Node1, [Key], [1], ignore, static, Bucket),
@@ -156,7 +155,7 @@ multiple_cluster_failure_test(Config) ->
         {ok, false} ->
             ct:pal("Logging is disabled!"),
             pass;
-        _ ->
+        {ok, true} ->
             update_counters(Node1, [Key], [1], ignore, static, Bucket),
             update_counters(Node1, [Key], [1], ignore, static, Bucket),
             {ok, CommitTime} = update_counters(Node1, [Key], [1], ignore, static, Bucket),
@@ -200,7 +199,7 @@ update_during_cluster_failure_test(Config) ->
         {ok, false} ->
             ct:pal("Logging is disabled!"),
             pass;
-        _ ->
+        {ok, true} ->
             update_counters(Node1, [Key], [1], ignore, static, Bucket),
             update_counters(Node1, [Key], [1], ignore, static, Bucket),
             {ok, CommitTime} = update_counters(Node1, [Key], [1], ignore, static, Bucket),
@@ -242,6 +241,7 @@ update_during_cluster_failure_test(Config) ->
 
 % Similar to the previous test, but uses more updates to better test log recovery
 update_during_cluster_failure_test2(Config) ->
+    ct:timetrap({seconds,240}),
     Bucket = ?BUCKET,
     Clusters = proplists:get_value(clusters, Config),
     [Node1, Node2, Node3 | _Nodes] =  [ hd(Cluster)|| Cluster <- Clusters ],
@@ -252,7 +252,7 @@ update_during_cluster_failure_test2(Config) ->
         {ok, false} ->
             ct:pal("Logging is disabled!"),
             pass;
-        _ ->
+        {ok, true} ->
             {ok, CommitTime} = update_counter_n(Node1, Key, 1000, ignore, static, Bucket),
             ct:log("Done append in Node1"),
 
@@ -306,7 +306,7 @@ update_during_cluster_failure_test3(Config) ->
         {ok, false} ->
             ct:pal("Logging is disabled!"),
             pass;
-        _ ->
+        {ok, true} ->
             update_counters(Node1, [Key], [1], ignore, static, Bucket),
             update_counters(Node1, [Key], [1], ignore, static, Bucket),
             {ok, CommitTime} = update_counters(Node1, [Key], [1], ignore, static, Bucket),


### PR DESCRIPTION
I suspect newer Erlang versions take a longer time resolve the host name. This causes local eunit tests with a 'nohost' domain to trigger the eunit default test timeout. Increasing the timeout fixes the issue.