### PR TITLE
Lock plugin versions and OTP upgrade

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy: 
       matrix:
-        erlang: [ 21,22,23,24 ]
+        erlang: [ 23,24 ]
 
     container:
       image: erlang:${{ matrix.erlang }}
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy: 
       matrix:
-        erlang: [ 21,22,23,24 ]
+        erlang: [ 23,24 ]
 
     container:
       image: erlang:${{ matrix.erlang }}
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy: 
       matrix:
-        erlang: [ 21,22,23,24 ]
+        erlang: [ 23,24 ]
 
     container:
       image: erlang:${{ matrix.erlang }}

--- a/apps/antidote/include/inter_dc_repl.hrl
+++ b/apps/antidote/include/inter_dc_repl.hrl
@@ -2,19 +2,17 @@
 
 -export_type([descriptor/0, interdc_txn/0, recvr_state/0, request_cache_entry/0]).
 
--record(recvr_state,
-    {
-        % TODO: this may not be required
-        lastRecvd :: orddict:orddict(),
-        lastCommitted :: orddict:orddict(),
-        %%Track timestamps from other DC which have been committed by this DC
+-record(recvr_state, {
+    % TODO: this may not be required
+    lastRecvd :: orddict:orddict(),
+    lastCommitted :: orddict:orddict(),
+    %%Track timestamps from other DC which have been committed by this DC
 
-        %% Holds receiving updates from each DC separately in causal order.
-        recQ :: orddict:orddict(),
-        statestore,
-        partition
-    }
-).
+    %% Holds receiving updates from each DC separately in causal order.
+    recQ :: orddict:orddict(),
+    statestore,
+    partition
+}).
 -type recvr_state() :: #recvr_state{}.
 
 -type socket_address() :: {inet:ip_address(), inet:port_number()}.

--- a/apps/antidote/src/clocksi_readitem.erl
+++ b/apps/antidote/src/clocksi_readitem.erl
@@ -104,7 +104,7 @@ async_validate_or_read_data_item(
                 {ok, valid} ->
                     gen_statem:cast(Sender, {ok, {valid, Key, Type}});
                 {error, Reason} ->
-                     gen_statem:cast(Sender, {error, Reason})
+                    gen_statem:cast(Sender, {error, Reason})
             end
         }
     end),

--- a/apps/antidote_pb_codec/include/antidote_pb.hrl
+++ b/apps/antidote_pb_codec/include/antidote_pb.hrl
@@ -9,14 +9,12 @@
 
 -ifndef('APBERRORRESP_PB_H').
 -define('APBERRORRESP_PB_H', true).
--record('ApbErrorResp',
-    {
-        %  = 1
-        errmsg :: iodata(),
-        % = 2, 32 bits
-        errcode :: non_neg_integer()
-    }
-).
+-record('ApbErrorResp', {
+    %  = 1
+    errmsg :: iodata(),
+    % = 2, 32 bits
+    errcode :: non_neg_integer()
+}).
 -endif.
 
 -ifndef('APBCOUNTERUPDATE_PB_H').
@@ -37,16 +35,14 @@
 
 -ifndef('APBSETUPDATE_PB_H').
 -define('APBSETUPDATE_PB_H', true).
--record('ApbSetUpdate',
-    {
-        %  = 1, enum ApbSetUpdate.SetOpType
-        optype :: 'ADD' | 'REMOVE' | integer(),
-        % = 2
-        adds = [] :: [iodata()] | undefined,
-        % = 3
-        rems = [] :: [iodata()] | undefined
-    }
-).
+-record('ApbSetUpdate', {
+    %  = 1, enum ApbSetUpdate.SetOpType
+    optype :: 'ADD' | 'REMOVE' | integer(),
+    % = 2
+    adds = [] :: [iodata()] | undefined,
+    % = 3
+    rems = [] :: [iodata()] | undefined
+}).
 -endif.
 
 -ifndef('APBGETSETRESP_PB_H').
@@ -83,50 +79,44 @@
 
 -ifndef('APBMAPKEY_PB_H').
 -define('APBMAPKEY_PB_H', true).
--record('ApbMapKey',
-    {
-        %  = 1
-        key :: iodata(),
-        % = 2, enum CRDT_type
-        type ::
-            'COUNTER'
-            | 'ORSET'
-            | 'LWWREG'
-            | 'MVREG'
-            | 'GMAP'
-            | 'RWSET'
-            | 'RRMAP'
-            | 'FATCOUNTER'
-            | 'FLAG_EW'
-            | 'FLAG_DW'
-            | 'BCOUNTER'
-            | integer()
-    }
-).
+-record('ApbMapKey', {
+    %  = 1
+    key :: iodata(),
+    % = 2, enum CRDT_type
+    type ::
+        'COUNTER'
+        | 'ORSET'
+        | 'LWWREG'
+        | 'MVREG'
+        | 'GMAP'
+        | 'RWSET'
+        | 'RRMAP'
+        | 'FATCOUNTER'
+        | 'FLAG_EW'
+        | 'FLAG_DW'
+        | 'BCOUNTER'
+        | integer()
+}).
 -endif.
 
 -ifndef('APBMAPUPDATE_PB_H').
 -define('APBMAPUPDATE_PB_H', true).
--record('ApbMapUpdate',
-    {
-        %  = 1
-        updates = [] :: [antidote_pb:'ApbMapNestedUpdate'()] | undefined,
-        % = 2
-        removedKeys = [] :: [antidote_pb:'ApbMapKey'()] | undefined
-    }
-).
+-record('ApbMapUpdate', {
+    %  = 1
+    updates = [] :: [antidote_pb:'ApbMapNestedUpdate'()] | undefined,
+    % = 2
+    removedKeys = [] :: [antidote_pb:'ApbMapKey'()] | undefined
+}).
 -endif.
 
 -ifndef('APBMAPNESTEDUPDATE_PB_H').
 -define('APBMAPNESTEDUPDATE_PB_H', true).
--record('ApbMapNestedUpdate',
-    {
-        %  = 1
-        key :: antidote_pb:'ApbMapKey'(),
-        % = 2
-        update :: antidote_pb:'ApbUpdateOperation'()
-    }
-).
+-record('ApbMapNestedUpdate', {
+    %  = 1
+    key :: antidote_pb:'ApbMapKey'(),
+    % = 2
+    update :: antidote_pb:'ApbUpdateOperation'()
+}).
 -endif.
 
 -ifndef('APBGETMAPRESP_PB_H').
@@ -139,14 +129,12 @@
 
 -ifndef('APBMAPENTRY_PB_H').
 -define('APBMAPENTRY_PB_H', true).
--record('ApbMapEntry',
-    {
-        %  = 1
-        key :: antidote_pb:'ApbMapKey'(),
-        % = 2
-        value :: antidote_pb:'ApbReadObjectResp'()
-    }
-).
+-record('ApbMapEntry', {
+    %  = 1
+    key :: antidote_pb:'ApbMapKey'(),
+    % = 2
+    value :: antidote_pb:'ApbReadObjectResp'()
+}).
 -endif.
 
 -ifndef('APBFLAGUPDATE_PB_H').
@@ -172,138 +160,120 @@
 
 -ifndef('APBOPERATIONRESP_PB_H').
 -define('APBOPERATIONRESP_PB_H', true).
--record('ApbOperationResp',
-    {
-        %  = 1
-        success :: boolean() | 0 | 1,
-        % = 2, 32 bits
-        errorcode :: non_neg_integer() | undefined
-    }
-).
+-record('ApbOperationResp', {
+    %  = 1
+    success :: boolean() | 0 | 1,
+    % = 2, 32 bits
+    errorcode :: non_neg_integer() | undefined
+}).
 -endif.
 
 -ifndef('APBTXNPROPERTIES_PB_H').
 -define('APBTXNPROPERTIES_PB_H', true).
--record('ApbTxnProperties',
-    {
-        %  = 1, 32 bits
-        read_write :: non_neg_integer() | undefined,
-        % = 2, 32 bits
-        red_blue :: non_neg_integer() | undefined,
-        % = 3
-        shared_locks = [] :: [iodata()] | undefined,
-        % = 4
-        exclusive_locks = [] :: [iodata()] | undefined
-    }
-).
+-record('ApbTxnProperties', {
+    %  = 1, 32 bits
+    read_write :: non_neg_integer() | undefined,
+    % = 2, 32 bits
+    red_blue :: non_neg_integer() | undefined,
+    % = 3
+    shared_locks = [] :: [iodata()] | undefined,
+    % = 4
+    exclusive_locks = [] :: [iodata()] | undefined
+}).
 -endif.
 
 -ifndef('APBBOUNDOBJECT_PB_H').
 -define('APBBOUNDOBJECT_PB_H', true).
--record('ApbBoundObject',
-    {
-        %  = 1
-        key :: iodata(),
-        % = 2, enum CRDT_type
-        type ::
-            'COUNTER'
-            | 'ORSET'
-            | 'LWWREG'
-            | 'MVREG'
-            | 'GMAP'
-            | 'RWSET'
-            | 'RRMAP'
-            | 'FATCOUNTER'
-            | 'FLAG_EW'
-            | 'FLAG_DW'
-            | 'BCOUNTER'
-            | integer(),
-        % = 3
-        bucket :: iodata()
-    }
-).
+-record('ApbBoundObject', {
+    %  = 1
+    key :: iodata(),
+    % = 2, enum CRDT_type
+    type ::
+        'COUNTER'
+        | 'ORSET'
+        | 'LWWREG'
+        | 'MVREG'
+        | 'GMAP'
+        | 'RWSET'
+        | 'RRMAP'
+        | 'FATCOUNTER'
+        | 'FLAG_EW'
+        | 'FLAG_DW'
+        | 'BCOUNTER'
+        | integer(),
+    % = 3
+    bucket :: iodata()
+}).
 -endif.
 
 -ifndef('APBREADOBJECTS_PB_H').
 -define('APBREADOBJECTS_PB_H', true).
--record('ApbReadObjects',
-    {
-        %  = 1
-        boundobjects = [] :: [antidote_pb:'ApbBoundObject'()] | undefined,
-        % = 2
-        transaction_descriptor :: iodata()
-    }
-).
+-record('ApbReadObjects', {
+    %  = 1
+    boundobjects = [] :: [antidote_pb:'ApbBoundObject'()] | undefined,
+    % = 2
+    transaction_descriptor :: iodata()
+}).
 -endif.
 
 -ifndef('APBVALIDATEORREADOBJECTS_PB_H').
 -define('APBVALIDATEORREADOBJECTS_PB_H', true).
--record('ApbValidateOrReadObjects',
-    {
-        %  = 1
-        boundobjects = [] :: [antidote_pb:'ApbBoundObject'()] | undefined,
-        % = 2
-        object_tokens = [] :: [iodata()] | undefined,
-        % = 3
-        transaction_descriptor :: iodata()
-    }
-).
+-record('ApbValidateOrReadObjects', {
+    %  = 1
+    boundobjects = [] :: [antidote_pb:'ApbBoundObject'()] | undefined,
+    % = 2
+    object_tokens = [] :: [iodata()] | undefined,
+    % = 3
+    transaction_descriptor :: iodata()
+}).
 -endif.
 
 -ifndef('APBUPDATEOP_PB_H').
 -define('APBUPDATEOP_PB_H', true).
--record('ApbUpdateOp',
-    {
-        %  = 1
-        boundobject :: antidote_pb:'ApbBoundObject'(),
-        % = 2
-        operation :: antidote_pb:'ApbUpdateOperation'()
-    }
-).
+-record('ApbUpdateOp', {
+    %  = 1
+    boundobject :: antidote_pb:'ApbBoundObject'(),
+    % = 2
+    operation :: antidote_pb:'ApbUpdateOperation'()
+}).
 -endif.
 
 -ifndef('APBUPDATEOPERATION_PB_H').
 -define('APBUPDATEOPERATION_PB_H', true).
--record('ApbUpdateOperation',
-    {
-        %  = 1
-        counterop :: antidote_pb:'ApbCounterUpdate'() | undefined,
-        % = 2
-        setop :: antidote_pb:'ApbSetUpdate'() | undefined,
-        % = 3
-        regop :: antidote_pb:'ApbRegUpdate'() | undefined,
-        % = 5
-        mapop :: antidote_pb:'ApbMapUpdate'() | undefined,
-        % = 6
-        resetop :: antidote_pb:'ApbCrdtReset'() | undefined,
-        % = 7
-        flagop :: antidote_pb:'ApbFlagUpdate'() | undefined
-    }
-).
+-record('ApbUpdateOperation', {
+    %  = 1
+    counterop :: antidote_pb:'ApbCounterUpdate'() | undefined,
+    % = 2
+    setop :: antidote_pb:'ApbSetUpdate'() | undefined,
+    % = 3
+    regop :: antidote_pb:'ApbRegUpdate'() | undefined,
+    % = 5
+    mapop :: antidote_pb:'ApbMapUpdate'() | undefined,
+    % = 6
+    resetop :: antidote_pb:'ApbCrdtReset'() | undefined,
+    % = 7
+    flagop :: antidote_pb:'ApbFlagUpdate'() | undefined
+}).
 -endif.
 
 -ifndef('APBUPDATEOBJECTS_PB_H').
 -define('APBUPDATEOBJECTS_PB_H', true).
--record('ApbUpdateObjects',
-    {
-        %  = 1
-        updates = [] :: [antidote_pb:'ApbUpdateOp'()] | undefined,
-        % = 2
-        transaction_descriptor :: iodata()
-    }
-).
+-record('ApbUpdateObjects', {
+    %  = 1
+    updates = [] :: [antidote_pb:'ApbUpdateOp'()] | undefined,
+    % = 2
+    transaction_descriptor :: iodata()
+}).
 -endif.
 
 -ifndef('APBSTARTTRANSACTION_PB_H').
 -define('APBSTARTTRANSACTION_PB_H', true).
--record('ApbStartTransaction',
-    {
-        %  = 1
-        timestamp :: iodata() | undefined,
-        % = 2
-        properties :: antidote_pb:'ApbTxnProperties'() | undefined
-    }
-).
+-record('ApbStartTransaction', {
+    %  = 1
+    timestamp :: iodata() | undefined,
+    % = 2
+    properties :: antidote_pb:'ApbTxnProperties'() | undefined
+}).
 -endif.
 
 -ifndef('APBABORTTRANSACTION_PB_H').
@@ -324,116 +294,100 @@
 
 -ifndef('APBSTATICUPDATEOBJECTS_PB_H').
 -define('APBSTATICUPDATEOBJECTS_PB_H', true).
--record('ApbStaticUpdateObjects',
-    {
-        %  = 1
-        transaction :: antidote_pb:'ApbStartTransaction'(),
-        % = 2
-        updates = [] :: [antidote_pb:'ApbUpdateOp'()] | undefined
-    }
-).
+-record('ApbStaticUpdateObjects', {
+    %  = 1
+    transaction :: antidote_pb:'ApbStartTransaction'(),
+    % = 2
+    updates = [] :: [antidote_pb:'ApbUpdateOp'()] | undefined
+}).
 -endif.
 
 -ifndef('APBSTATICREADOBJECTS_PB_H').
 -define('APBSTATICREADOBJECTS_PB_H', true).
--record('ApbStaticReadObjects',
-    {
-        %  = 1
-        transaction :: antidote_pb:'ApbStartTransaction'(),
-        % = 2
-        objects = [] :: [antidote_pb:'ApbBoundObject'()] | undefined
-    }
-).
+-record('ApbStaticReadObjects', {
+    %  = 1
+    transaction :: antidote_pb:'ApbStartTransaction'(),
+    % = 2
+    objects = [] :: [antidote_pb:'ApbBoundObject'()] | undefined
+}).
 -endif.
 
 -ifndef('APBSTARTTRANSACTIONRESP_PB_H').
 -define('APBSTARTTRANSACTIONRESP_PB_H', true).
--record('ApbStartTransactionResp',
-    {
-        %  = 1
-        success :: boolean() | 0 | 1,
-        % = 2
-        transaction_descriptor :: iodata() | undefined,
-        % = 3, 32 bits
-        errorcode :: non_neg_integer() | undefined
-    }
-).
+-record('ApbStartTransactionResp', {
+    %  = 1
+    success :: boolean() | 0 | 1,
+    % = 2
+    transaction_descriptor :: iodata() | undefined,
+    % = 3, 32 bits
+    errorcode :: non_neg_integer() | undefined
+}).
 -endif.
 
 -ifndef('APBREADOBJECTRESP_PB_H').
 -define('APBREADOBJECTRESP_PB_H', true).
--record('ApbReadObjectResp',
-    {
-        %  = 1
-        counter :: antidote_pb:'ApbGetCounterResp'() | undefined,
-        % = 2
-        set :: antidote_pb:'ApbGetSetResp'() | undefined,
-        % = 3
-        reg :: antidote_pb:'ApbGetRegResp'() | undefined,
-        % = 4
-        mvreg :: antidote_pb:'ApbGetMVRegResp'() | undefined,
-        % = 6
-        map :: antidote_pb:'ApbGetMapResp'() | undefined,
-        % = 7
-        flag :: antidote_pb:'ApbGetFlagResp'() | undefined
-    }
-).
+-record('ApbReadObjectResp', {
+    %  = 1
+    counter :: antidote_pb:'ApbGetCounterResp'() | undefined,
+    % = 2
+    set :: antidote_pb:'ApbGetSetResp'() | undefined,
+    % = 3
+    reg :: antidote_pb:'ApbGetRegResp'() | undefined,
+    % = 4
+    mvreg :: antidote_pb:'ApbGetMVRegResp'() | undefined,
+    % = 6
+    map :: antidote_pb:'ApbGetMapResp'() | undefined,
+    % = 7
+    flag :: antidote_pb:'ApbGetFlagResp'() | undefined
+}).
 -endif.
 
 -ifndef('APBREADOBJECTSRESP_PB_H').
 -define('APBREADOBJECTSRESP_PB_H', true).
--record('ApbReadObjectsResp',
-    {
-        %  = 1
-        success :: boolean() | 0 | 1,
-        % = 2
-        objects = [] :: [antidote_pb:'ApbReadObjectResp'()] | undefined,
-        % = 3, 32 bits
-        errorcode :: non_neg_integer() | undefined
-    }
-).
+-record('ApbReadObjectsResp', {
+    %  = 1
+    success :: boolean() | 0 | 1,
+    % = 2
+    objects = [] :: [antidote_pb:'ApbReadObjectResp'()] | undefined,
+    % = 3, 32 bits
+    errorcode :: non_neg_integer() | undefined
+}).
 -endif.
 
 -ifndef('APBVALIDATEORREADOBJECTSRESP_PB_H').
 -define('APBVALIDATEORREADOBJECTSRESP_PB_H', true).
--record('ApbValidateOrReadObjectsResp',
-    {
-        %  = 1
-        success :: boolean() | 0 | 1,
-        % = 2
-        objects = [] :: [antidote_pb:'ApbReadObjectResp'()] | undefined,
-        % = 3
-        tokens = [] :: [iodata()] | undefined,
-        % = 4, 32 bits
-        errorcode :: non_neg_integer() | undefined
-    }
-).
+-record('ApbValidateOrReadObjectsResp', {
+    %  = 1
+    success :: boolean() | 0 | 1,
+    % = 2
+    objects = [] :: [antidote_pb:'ApbReadObjectResp'()] | undefined,
+    % = 3
+    tokens = [] :: [iodata()] | undefined,
+    % = 4, 32 bits
+    errorcode :: non_neg_integer() | undefined
+}).
 -endif.
 
 -ifndef('APBCOMMITRESP_PB_H').
 -define('APBCOMMITRESP_PB_H', true).
--record('ApbCommitResp',
-    {
-        %  = 1
-        success :: boolean() | 0 | 1,
-        % = 2
-        commit_time :: iodata() | undefined,
-        % = 3, 32 bits
-        errorcode :: non_neg_integer() | undefined
-    }
-).
+-record('ApbCommitResp', {
+    %  = 1
+    success :: boolean() | 0 | 1,
+    % = 2
+    commit_time :: iodata() | undefined,
+    % = 3, 32 bits
+    errorcode :: non_neg_integer() | undefined
+}).
 -endif.
 
 -ifndef('APBSTATICREADOBJECTSRESP_PB_H').
 -define('APBSTATICREADOBJECTSRESP_PB_H', true).
--record('ApbStaticReadObjectsResp',
-    {
-        %  = 1
-        objects :: antidote_pb:'ApbReadObjectsResp'(),
-        % = 2
-        committime :: antidote_pb:'ApbCommitResp'()
-    }
-).
+-record('ApbStaticReadObjectsResp', {
+    %  = 1
+    objects :: antidote_pb:'ApbReadObjectsResp'(),
+    % = 2
+    committime :: antidote_pb:'ApbCommitResp'()
+}).
 -endif.
 
 -ifndef('APBCREATEDC_PB_H').
@@ -446,14 +400,12 @@
 
 -ifndef('APBCREATEDCRESP_PB_H').
 -define('APBCREATEDCRESP_PB_H', true).
--record('ApbCreateDCResp',
-    {
-        %  = 1
-        success :: boolean() | 0 | 1,
-        % = 2, 32 bits
-        errorcode :: non_neg_integer() | undefined
-    }
-).
+-record('ApbCreateDCResp', {
+    %  = 1
+    success :: boolean() | 0 | 1,
+    % = 2, 32 bits
+    errorcode :: non_neg_integer() | undefined
+}).
 -endif.
 
 -ifndef('APBGETCONNECTIONDESCRIPTOR_PB_H').
@@ -463,16 +415,14 @@
 
 -ifndef('APBGETCONNECTIONDESCRIPTORRESP_PB_H').
 -define('APBGETCONNECTIONDESCRIPTORRESP_PB_H', true).
--record('ApbGetConnectionDescriptorResp',
-    {
-        %  = 1
-        success :: boolean() | 0 | 1,
-        % = 2
-        descriptor :: iodata() | undefined,
-        % = 3, 32 bits
-        errorcode :: non_neg_integer() | undefined
-    }
-).
+-record('ApbGetConnectionDescriptorResp', {
+    %  = 1
+    success :: boolean() | 0 | 1,
+    % = 2
+    descriptor :: iodata() | undefined,
+    % = 3, 32 bits
+    errorcode :: non_neg_integer() | undefined
+}).
 -endif.
 
 -ifndef('APBCONNECTTODCS_PB_H').
@@ -485,14 +435,12 @@
 
 -ifndef('APBCONNECTTODCSRESP_PB_H').
 -define('APBCONNECTTODCSRESP_PB_H', true).
--record('ApbConnectToDCsResp',
-    {
-        %  = 1
-        success :: boolean() | 0 | 1,
-        % = 2, 32 bits
-        errorcode :: non_neg_integer() | undefined
-    }
-).
+-record('ApbConnectToDCsResp', {
+    %  = 1
+    success :: boolean() | 0 | 1,
+    % = 2, 32 bits
+    errorcode :: non_neg_integer() | undefined
+}).
 -endif.
 
 -endif.

--- a/rebar.config
+++ b/rebar.config
@@ -2,11 +2,12 @@
 {deps, []}.
 
 {project_plugins, [
-  {erlfmt, "v1.0.0"}, 
-  {rebar3_lint, "v1.0.2"}, 
-  {rebar3_proper, "v0.12.1"}, 
-  {rebar3_path_deps, "v0.4.0"}, 
-  {coveralls, "v2.2.0"}
+    {erlfmt, "v1.0.0"},
+    {rebar3_format, "v1.2.0"},
+    {rebar3_lint, "v1.0.2"},
+    {rebar3_proper, "v0.12.1"},
+    {rebar3_path_deps, "v0.4.0"},
+    {coveralls, "v2.2.0"}
 ]}.
 
 {format, [

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,14 @@
 {erl_opts, [debug_info]}.
 {deps, []}.
 
-{project_plugins, [rebar3_format, erlfmt, rebar3_lint, rebar3_proper, rebar3_path_deps, coveralls]}.
+{project_plugins, [
+  {erlfmt, "v1.0.0"}, 
+  {rebar3_lint, "v1.0.2"}, 
+  {rebar3_proper, "v0.12.1"}, 
+  {rebar3_path_deps, "v0.4.0"}, 
+  {coveralls, "v2.2.0"}
+]}.
+
 {format, [
     {files, ["apps/*/src/*.erl", "apps/*/include/*.hrl", "**/rebar.config"]},
     %% The erlfmt formatter interface


### PR DESCRIPTION
Remove support for older OTP versions, linting requires OTP 23

* Workflow uses Erlang 23 & 24
* Locked rebar3 plugins
* Formatted all files with `erlfmt`