### PR TITLE
Failing test case due to key overlap

### DIFF
--- a/apps/antidote/test/multidc/multiple_dcs_node_failure_SUITE.erl
+++ b/apps/antidote/test/multidc/multiple_dcs_node_failure_SUITE.erl
@@ -245,7 +245,7 @@ update_during_cluster_failure_test2(Config) ->
     Bucket = ?BUCKET,
     Clusters = proplists:get_value(clusters, Config),
     [Node1, Node2, Node3 | _Nodes] =  [ hd(Cluster)|| Cluster <- Clusters ],
-    Key = update_during_cluster_failure_test,
+    Key = update_during_cluster_failure_test2,
     Type = antidote_crdt_counter_pn,
 
     case rpc:call(Node1, application, get_env, [antidote, enable_logging]) of
@@ -299,7 +299,7 @@ update_during_cluster_failure_test3(Config) ->
     Bucket = ?BUCKET,
     Clusters = proplists:get_value(clusters, Config),
     [Node1, Node2, Node3 | _Nodes] =  [ hd(Cluster)|| Cluster <- Clusters ],
-    Key = update_during_cluster_failure_test,
+    Key = update_during_cluster_failure_test3,
     Type = antidote_crdt_counter_pn,
 
     case rpc:call(Node1, application, get_env, [antidote, enable_logging]) of


### PR DESCRIPTION
Three of the tests were using the same key for updates, which created some unintended interdependence of the tests. Renamed them.